### PR TITLE
[Closes #1] Feat: Member 엔티티 생성

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/Member.java
@@ -1,0 +1,55 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="MEMBER_TB")
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 100, nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 300, nullable = true)
+    private String password;
+
+    @Column(nullable = false, name="uid")
+    private String UID;
+
+    @Column(length = 500, nullable = true, name="profile_image")
+    private String profileImage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RoleEnum role;
+
+    @CreatedDate
+    @Column(nullable = false, name="created_date")
+    private LocalDateTime createdDate;
+
+    @Embedded
+    private MemberInfoVO memberInfo;
+
+
+    protected Member() {}
+
+    public Member(String email, String password, String UID, String profileImage, RoleEnum role, MemberInfoVO memberInfo) {
+        this.email = email;
+        this.password = password;
+        this.UID = UID;
+        this.profileImage = profileImage;
+        this.role = role;
+        this.createdDate = LocalDateTime.now();
+        this.memberInfo = memberInfo;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/Member.java
@@ -1,5 +1,6 @@
 package com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity;
 
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public class Member {
     @Column(length = 300, nullable = true)
     private String password;
 
-    @Column(nullable = false, name="uid")
+    @Column(nullable = true, name="uid")
     private String UID;
 
     @Column(length = 500, nullable = true, name="profile_image")
@@ -32,6 +33,10 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RoleEnum role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private PlatformEnum platform;
 
     @CreatedDate
     @Column(nullable = false, name="created_date")
@@ -43,13 +48,43 @@ public class Member {
 
     protected Member() {}
 
-    public Member(String email, String password, String UID, String profileImage, RoleEnum role, MemberInfoVO memberInfo) {
+    // 자체 로그인 시
+    public Member(String email, String password, RoleEnum role, MemberInfoVO memberInfo) {
         this.email = email;
         this.password = password;
+        this.role = role;
+        this.createdDate = LocalDateTime.now();
+        this.memberInfo = memberInfo;
+    }
+
+    // 소셜 로그인 시
+    public Member(String email, String UID, String profileImage, RoleEnum role, PlatformEnum platform, MemberInfoVO memberInfo) {
+        this.email = email;
         this.UID = UID;
         this.profileImage = profileImage;
         this.role = role;
+        this.platform = platform;
         this.createdDate = LocalDateTime.now();
+        this.memberInfo = memberInfo;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void setRole(RoleEnum role) {
+        this.role = role;
+    }
+
+    public void setMemberInfo(MemberInfoVO memberInfo) {
         this.memberInfo = memberInfo;
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/AgeRangeEnum.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/AgeRangeEnum.java
@@ -1,0 +1,21 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype;
+
+import lombok.Getter;
+
+@Getter
+public enum AgeRangeEnum {
+
+    TEN("RANGE_TEN", "10대"),
+    TWENTY("RANGE_TWENTY", "20대"),
+    THIRSTY("RANGE_THIRSTY", "30대"),
+    FORTY("RANGE_FORTY", "40대"),
+    FIFTY("RANGE_FIFTY", "50대"),
+    SIXTY("RANGE_SIXTY", "60대");
+    private final String key;
+    private final String title;
+
+    AgeRangeEnum(String key, String title) {
+        this.title = title;
+        this.key = key;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/GenderEnum.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/GenderEnum.java
@@ -1,0 +1,7 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype;
+
+public enum GenderEnum {
+
+    MALE,
+    FEMALE
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/PlatformEnum.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/PlatformEnum.java
@@ -1,0 +1,6 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype;
+
+public enum PlatformEnum {
+
+    GOOGLE
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/RoleEnum.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/enumtype/RoleEnum.java
@@ -1,0 +1,18 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype;
+
+import lombok.Getter;
+
+@Getter
+public enum RoleEnum {
+    GUEST("ROLE_GUEST", "손님"),
+    MEMBER("ROLE_MEMBER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+
+    RoleEnum(String key, String title) {
+        this.key = key;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/vo/MemberInfoVO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/vo/MemberInfoVO.java
@@ -1,0 +1,72 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.AgeRangeEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.GenderEnum;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Embeddable
+public class MemberInfoVO {
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GenderEnum gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, name="age_range")
+    private AgeRangeEnum ageRange;
+
+    @Column(nullable = false)
+    private String job;
+
+    protected MemberInfoVO() {}
+
+    public MemberInfoVO(String name, GenderEnum gender, AgeRangeEnum ageRange, String job) {
+        this.name = name;
+        this.gender = gender;
+        this.ageRange = ageRange;
+        this.job = job;
+    }
+
+    public GenderEnum getGender() {
+        return gender;
+    }
+
+    public MemberInfoVO setGender(GenderEnum gender) {
+        this.gender = gender;
+        return this;
+    }
+
+    public AgeRangeEnum getAgeRange() {
+        return ageRange;
+    }
+
+    public MemberInfoVO setAgeRange(AgeRangeEnum ageRange) {
+        this.ageRange = ageRange;
+        return this;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public MemberInfoVO setJob(String job) {
+        this.job = job;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public MemberInfoVO setName(String name) {
+        this.name = name;
+        return this;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/vo/MemberInfoVO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/vo/MemberInfoVO.java
@@ -11,21 +11,22 @@ import javax.persistence.Enumerated;
 @Embeddable
 public class MemberInfoVO {
 
-    @Column(length = 100, nullable = false)
+    @Column(length = 100, nullable = false, name="name")
     private String name;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, name="gender")
     private GenderEnum gender;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, name="age_range")
     private AgeRangeEnum ageRange;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name="job")
     private String job;
 
     protected MemberInfoVO() {}
+
 
     public MemberInfoVO(String name, GenderEnum gender, AgeRangeEnum ageRange, String job) {
         this.name = name;


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #1 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* Lifecycle이 다르거나, Entity의 적은 책임을 나눠주기 위해 MemberInfoVO로 중간객체를 만들어서, Member 엔티티를 생성하였습니다.
* MemberInfoVO의 데이터베이스 컬럼명을 member_info < 이런식으로 보이지 않게 컬럼 name을 부여하였습니다.
* 소셜 로그인 시 필요한 값들과, 자체 로그인 시 필요한 값들이 달라 생성자를 각각 생성하였습니다.
* MemberInfoVO에서 setter메소드 이용할 때 자료형을 MemberInfoVO로 주고 return this를 적어서 set().set(). 이런식으로 구현하였습니다.
---

# 관련 스크린샷

---
 <img width="369" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/16571807-4856-44c1-b1c5-910b2a0ca342">

---

# 테스트 계획 또는 완료 사항

---
* 없음
