### PR TITLE
[Closes #18] Feat : 자세 로그 생성 어플리케이션 서비스 클래스 생성

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/CreatePostureDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/CreatePostureDTO.java
@@ -1,0 +1,25 @@
+package com.spinetracker.spinetracker.domain.posture.command.application.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@ToString
+public class CreatePostureDTO {
+    private final Long memberId;
+    private final String postureTag;
+    private final LocalDate date;
+    private final LocalTime startTime;
+    private final LocalTime endTime;
+
+    public CreatePostureDTO(Long memberId, String postureTag, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        this.memberId = memberId;
+        this.postureTag = postureTag;
+        this.date = date;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/CreatePostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/CreatePostureLogService.java
@@ -1,0 +1,35 @@
+package com.spinetracker.spinetracker.domain.posture.command.application.service;
+
+import com.spinetracker.spinetracker.domain.posture.command.application.dto.CreatePostureDTO;
+import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.entity.PostureLog;
+import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.enumtype.PostureTag;
+import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.vo.DateTimeVO;
+import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.vo.MemberVO;
+import com.spinetracker.spinetracker.domain.posture.command.domain.repository.PostureLogRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreatePostureLogService {
+
+    private final PostureLogRepository postureLogRepository;
+
+    @Autowired
+    public CreatePostureLogService(PostureLogRepository postureLogRepository) {
+        this.postureLogRepository = postureLogRepository;
+    }
+
+    public PostureLog create(CreatePostureDTO createPostureDTO) {
+
+        MemberVO member = new MemberVO(createPostureDTO.getMemberId());
+        DateTimeVO dateTime = new DateTimeVO(
+                createPostureDTO.getDate(),
+                createPostureDTO.getStartTime(),
+                createPostureDTO.getEndTime()
+        );
+        PostureTag postureTag = PostureTag.valueOf(createPostureDTO.getPostureTag());
+        PostureLog newPostureLog = new PostureLog(member, postureTag, dateTime);
+
+        return postureLogRepository.save(newPostureLog);
+    };
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/domain/repository/PostureLogRepository.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/domain/repository/PostureLogRepository.java
@@ -1,0 +1,10 @@
+package com.spinetracker.spinetracker.domain.posture.command.domain.repository;
+
+import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.entity.PostureLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostureLogRepository extends JpaRepository<PostureLog, Long> {
+
+}

--- a/src/test/java/com/spinetracker/spinetracker/domain/posture/command/application/service/CreatePostureLogServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/posture/command/application/service/CreatePostureLogServiceTest.java
@@ -1,0 +1,55 @@
+package com.spinetracker.spinetracker.domain.posture.command.application.service;
+
+import com.spinetracker.spinetracker.domain.posture.command.application.dto.CreatePostureDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+
+@SpringBootTest
+@Transactional
+class CreatePostureLogServiceTest {
+
+    @Autowired
+    private CreatePostureLogService createPostureLogService;
+
+    private static Stream<Arguments> getPostureInfo() {
+        return Stream.of(
+                Arguments.of(
+                 new CreatePostureDTO(
+                        1L,
+                        "TEXTNECK",
+                        LocalDate.now(),
+                        LocalTime.now(),
+                         LocalTime.now().plusMinutes(10)
+                )
+            ),
+                Arguments.of(
+                        new CreatePostureDTO(
+                                1L,
+                                "ASYMMETRY",
+                                LocalDate.now(),
+                                LocalTime.now().plusMinutes(100),
+                                LocalTime.now().plusMinutes(110)
+                        )
+                )
+        );
+    }
+
+    @DisplayName("자세 로그 생성 DTO를 통해 생성이 되는지 확인")
+    @ParameterizedTest
+    @MethodSource("getPostureInfo")
+    void create(CreatePostureDTO createPostureDTO) {
+        Assertions.assertDoesNotThrow(
+                () -> createPostureLogService.create(createPostureDTO)
+        );
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #18 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `CreatePostureDTO`를 통해 dto 내의 값들을 중간 객체와 Enum 타입의 값으로 생성한 후 `PostureLog` 객체를 생성하였습니다.
---

# 관련 스크린샷
![CleanShot 2023-09-09 at 18 29 16](https://github.com/SpineTracker60/back-end/assets/19159759/e9a0220c-f2c0-49a8-b209-f23cb333a2e6)

---
*  테스트 코드를 통해 데이터가 정상적으로 저장되는지 확인하기 위해 IDE의 디버깅 기능을 통해 생성된 PostureLog 객체의 값들을 확인하였습니다.
---

# 테스트 계획 또는 완료 사항

---
<img width="1504" alt="CleanShot 2023-09-09 at 18 28 49@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/a0053fd6-0d73-47b9-a92f-02b1069643c3">

* 자세 로그 생성 DTO를 통해 생성이 되는지 확인을 완료하였습니다.
