### PR TITLE
[Closes #14] Feat: CREATE APPLICATION SERVICE 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:2.3.1'
     testImplementation 'org.springframework.security:spring-security-test'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreateMemberByLocalDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreateMemberByLocalDTO.java
@@ -1,0 +1,22 @@
+package com.spinetracker.spinetracker.domain.member.command.application.dto;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class CreateMemberByLocalDTO {
+    private final String email;
+    private final String password;
+    private final RoleEnum role;
+    private final MemberInfoVO memberInfo;
+
+    public CreateMemberByLocalDTO(String email, String password, RoleEnum role, MemberInfoVO memberInfo) {
+        this.email = email;
+        this.password = password;
+        this.role = role;
+        this.memberInfo = memberInfo;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreateMemberByLocalDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreateMemberByLocalDTO.java
@@ -1,22 +1,38 @@
 package com.spinetracker.spinetracker.domain.member.command.application.dto;
 
-import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
-import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
 import lombok.Getter;
 import lombok.ToString;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 @Getter
 @ToString
 public class CreateMemberByLocalDTO {
-    private final String email;
-    private final String password;
-    private final RoleEnum role;
-    private final MemberInfoVO memberInfo;
 
-    public CreateMemberByLocalDTO(String email, String password, RoleEnum role, MemberInfoVO memberInfo) {
+    @Email(message = "NOT_VALID_EMAIL")
+    private final String email;
+    @NotBlank(message = "PASSWORD_IS_MANDATORY")
+    @NotNull
+    private final String password;
+    private final String role;
+    @NotBlank(message = "NAME_IS_NOT_BLANK")
+    private final String name;
+    @NotBlank(message = "GENDER_IS_NOT_BLANK")
+    private final String gender;
+    @NotBlank(message = "AGERANGE_IS_NOT_BLANK")
+    private final String ageRange;
+    @NotBlank(message = "JOB_IS_NOT_BLANK")
+    private final String job;
+
+    public CreateMemberByLocalDTO(String email, String password, String name, String gender, String ageRange, String job) {
         this.email = email;
         this.password = password;
-        this.role = role;
-        this.memberInfo = memberInfo;
+        this.role = "MEMBER";
+        this.name = name;
+        this.gender = gender;
+        this.ageRange = ageRange;
+        this.job = job;
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreateMemberBySocialDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreateMemberBySocialDTO.java
@@ -1,0 +1,27 @@
+package com.spinetracker.spinetracker.domain.member.command.application.dto;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class CreateMemberBySocialDTO {
+    private final String email;
+    private final String UID;
+    private final String profileImage;
+    private final RoleEnum role;
+    private final PlatformEnum platformEnum;
+    private final MemberInfoVO memberInfo;
+
+    public CreateMemberBySocialDTO(String email, String UID, String profileImage, RoleEnum role, PlatformEnum platformEnum, MemberInfoVO memberInfo) {
+        this.email = email;
+        this.UID = UID;
+        this.profileImage = profileImage;
+        this.role = role;
+        this.platformEnum = platformEnum;
+        this.memberInfo = memberInfo;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/UpdateMemberByLocalDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/UpdateMemberByLocalDTO.java
@@ -1,0 +1,35 @@
+package com.spinetracker.spinetracker.domain.member.command.application.dto;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class UpdateMemberByLocalDTO {
+    private String password;
+    private RoleEnum role;
+    private MemberInfoVO memberInfo;
+
+    public UpdateMemberByLocalDTO(String password, RoleEnum role, MemberInfoVO memberInfo) {
+        this.password = password;
+        this.role = role;
+        this.memberInfo = memberInfo;
+    }
+
+    public UpdateMemberByLocalDTO setPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public UpdateMemberByLocalDTO setRole(RoleEnum role) {
+        this.role = role;
+        return this;
+    }
+
+    public UpdateMemberByLocalDTO setMemberInfo(MemberInfoVO memberInfo) {
+        this.memberInfo = memberInfo;
+        return this;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/UpdateMemberBySocialDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/UpdateMemberBySocialDTO.java
@@ -1,0 +1,35 @@
+package com.spinetracker.spinetracker.domain.member.command.application.dto;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class UpdateMemberBySocialDTO {
+    private String profileImage;
+    private RoleEnum role;
+    private MemberInfoVO memberInfo;
+
+    public UpdateMemberBySocialDTO(String profileImage, RoleEnum role, MemberInfoVO memberInfo) {
+        this.profileImage = profileImage;
+        this.role = role;
+        this.memberInfo = memberInfo;
+    }
+
+    public UpdateMemberBySocialDTO setProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+        return this;
+    }
+
+    public UpdateMemberBySocialDTO setRole(RoleEnum role) {
+        this.role = role;
+        return this;
+    }
+
+    public UpdateMemberBySocialDTO setMemberInfo(MemberInfoVO memberInfo) {
+        this.memberInfo = memberInfo;
+        return this;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/UpdateMemberBySocialDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/UpdateMemberBySocialDTO.java
@@ -1,5 +1,6 @@
 package com.spinetracker.spinetracker.domain.member.command.application.dto;
 
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
 import lombok.Getter;
@@ -8,13 +9,17 @@ import lombok.ToString;
 @Getter
 @ToString
 public class UpdateMemberBySocialDTO {
+    private String UID;
     private String profileImage;
     private RoleEnum role;
+    private PlatformEnum platformEnum;
     private MemberInfoVO memberInfo;
 
-    public UpdateMemberBySocialDTO(String profileImage, RoleEnum role, MemberInfoVO memberInfo) {
+    public UpdateMemberBySocialDTO(String UID, String profileImage, RoleEnum role, PlatformEnum platformEnum, MemberInfoVO memberInfo) {
+        this.UID = UID;
         this.profileImage = profileImage;
         this.role = role;
+        this.platformEnum = platformEnum;
         this.memberInfo = memberInfo;
     }
 

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberService.java
@@ -1,0 +1,42 @@
+package com.spinetracker.spinetracker.domain.member.command.application.service;
+
+import com.spinetracker.spinetracker.domain.member.command.application.dto.CreateMemberByLocalDTO;
+import com.spinetracker.spinetracker.domain.member.command.application.dto.CreateMemberBySocialDTO;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+import com.spinetracker.spinetracker.domain.member.command.domain.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateMemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public CreateMemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    // 자체 로그인 시
+    public Member createMemberByLocal(CreateMemberByLocalDTO createMemberByLocalDTO) {
+        Member createdMemberByLocal = new Member(
+                createMemberByLocalDTO.getEmail(),
+                createMemberByLocalDTO.getPassword(),
+                createMemberByLocalDTO.getRole(),
+                createMemberByLocalDTO.getMemberInfo()
+        );
+        return memberRepository.save(createdMemberByLocal);
+    }
+    // 소셜 로그인 시
+    public Member createMemberBySocial(CreateMemberBySocialDTO createMemberBySocialDTO) {
+        Member createdMemberBySocial = new Member(
+                createMemberBySocialDTO.getEmail(),
+                createMemberBySocialDTO.getUID(),
+                createMemberBySocialDTO.getProfileImage(),
+                createMemberBySocialDTO.getRole(),
+                createMemberBySocialDTO.getPlatformEnum(),
+                createMemberBySocialDTO.getMemberInfo()
+        );
+        return memberRepository.save(createdMemberBySocial);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberService.java
@@ -3,9 +3,14 @@ package com.spinetracker.spinetracker.domain.member.command.application.service;
 import com.spinetracker.spinetracker.domain.member.command.application.dto.CreateMemberByLocalDTO;
 import com.spinetracker.spinetracker.domain.member.command.application.dto.CreateMemberBySocialDTO;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.AgeRangeEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.GenderEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.vo.MemberInfoVO;
 import com.spinetracker.spinetracker.domain.member.command.domain.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CreateMemberService {
@@ -18,12 +23,24 @@ public class CreateMemberService {
     }
 
     // 자체 로그인 시
+    @Transactional
     public Member createMemberByLocal(CreateMemberByLocalDTO createMemberByLocalDTO) {
+
+        GenderEnum memberGender = GenderEnum.valueOf(createMemberByLocalDTO.getGender());
+        AgeRangeEnum memberAgeRange = AgeRangeEnum.valueOf(createMemberByLocalDTO.getAgeRange());
+        MemberInfoVO newMemberInfoVO = new MemberInfoVO(
+                createMemberByLocalDTO.getName(),
+                memberGender,
+                memberAgeRange,
+                createMemberByLocalDTO.getJob()
+        );
+
+        RoleEnum memberRole = RoleEnum.valueOf(createMemberByLocalDTO.getRole());
         Member createdMemberByLocal = new Member(
                 createMemberByLocalDTO.getEmail(),
                 createMemberByLocalDTO.getPassword(),
-                createMemberByLocalDTO.getRole(),
-                createMemberByLocalDTO.getMemberInfo()
+                memberRole,
+                newMemberInfoVO
         );
         return memberRepository.save(createdMemberByLocal);
     }

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/UpdateMemberService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/UpdateMemberService.java
@@ -1,0 +1,62 @@
+package com.spinetracker.spinetracker.domain.member.command.application.service;
+
+import com.spinetracker.spinetracker.domain.member.command.application.dto.UpdateMemberByLocalDTO;
+import com.spinetracker.spinetracker.domain.member.command.application.dto.UpdateMemberBySocialDTO;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+import com.spinetracker.spinetracker.domain.member.command.domain.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UpdateMemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public UpdateMemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    // 자체 로그인 시
+    public boolean updateMemberByLocal(Long memberId, UpdateMemberByLocalDTO updateMemberByLocalDTO) {
+        Optional<Member> findMemberByLocal = memberRepository.findById(memberId);
+        if (findMemberByLocal.isPresent()) {
+            Member updateMemberByLocal = findMemberByLocal.get();
+            if (updateMemberByLocalDTO.getPassword() != null) {
+                updateMemberByLocal.setPassword(updateMemberByLocalDTO.getPassword());
+            }
+            if (updateMemberByLocalDTO.getRole() != null) {
+                updateMemberByLocal.setRole(updateMemberByLocalDTO.getRole());
+            }
+            if (updateMemberByLocalDTO.getMemberInfo() != null) {
+                updateMemberByLocal.setMemberInfo(updateMemberByLocalDTO.getMemberInfo());
+            }
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // 소셜 로그인 시
+    public boolean updateMemberBySocial(Long memberId, UpdateMemberBySocialDTO updateMemberBySocialDTO) {
+        Optional<Member> findMemberBySocial = memberRepository.findById(memberId);
+        if (findMemberBySocial.isPresent()) {
+            Member updateMemberBySocial = findMemberBySocial.get();
+            if (updateMemberBySocialDTO.getProfileImage() != null) {
+                updateMemberBySocial.setProfileImage(updateMemberBySocialDTO.getProfileImage());
+            }
+            if (updateMemberBySocialDTO.getRole() != null) {
+                updateMemberBySocial.setRole(updateMemberBySocialDTO.getRole());
+            }
+            if (updateMemberBySocialDTO.getMemberInfo() != null) {
+                updateMemberBySocial.setMemberInfo(updateMemberBySocialDTO.getMemberInfo());
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/aggregate/entity/Member.java
@@ -68,20 +68,24 @@ public class Member {
         this.memberInfo = memberInfo;
     }
 
-    public void setEmail(String email) {
+    public Member setEmail(String email) {
         this.email = email;
+        return this;
     }
 
-    public void setPassword(String password) {
+    public Member setPassword(String password) {
         this.password = password;
+        return this;
     }
 
-    public void setProfileImage(String profileImage) {
+    public Member setProfileImage(String profileImage) {
         this.profileImage = profileImage;
+        return this;
     }
 
-    public void setRole(RoleEnum role) {
+    public Member setRole(RoleEnum role) {
         this.role = role;
+        return this;
     }
 
     public void setMemberInfo(MemberInfoVO memberInfo) {

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.repository;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberServiceTest.java
@@ -1,0 +1,7 @@
+package com.spinetracker.spinetracker.domain.member.command.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CreateMemberServiceTest {
+
+}

--- a/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberServiceTest.java
@@ -1,7 +1,58 @@
 package com.spinetracker.spinetracker.domain.member.command.application.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.spinetracker.spinetracker.domain.member.command.application.dto.CreateMemberByLocalDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+
+
+import java.util.stream.Stream;
+
+@SpringBootTest
+@Transactional
 class CreateMemberServiceTest {
 
+    @Autowired
+    private CreateMemberService createMemberService;
+
+    private static Stream<Arguments> getCreateMemberByLocalInfo() {
+        return Stream.of(
+                Arguments.of(
+                        new CreateMemberByLocalDTO(
+                                "email@test.com",
+                                "123456!@#",
+                                "효정",
+                                "FEMALE",
+                                "TEN",
+                                "학생"
+                        )
+                ),
+                Arguments.of(
+                        new CreateMemberByLocalDTO(
+                                "email2@test.com",
+                                "test1234!",
+                                "지원",
+                                "MALE",
+                                "TWENTY",
+                                "학생"
+                        )
+                )
+        );
+    }
+
+    @DisplayName("CreateMemberByLocalDTO를 통해 사용자 생성이 되는지 확인")
+    @ParameterizedTest
+    @MethodSource("getCreateMemberByLocalInfo")
+    void createMemberByLocal(CreateMemberByLocalDTO createMemberByLocalDTO) {
+
+        Assertions.assertDoesNotThrow(
+                () -> createMemberService.createMemberByLocal(createMemberByLocalDTO)
+        );
+    }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #14 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 데이터베이스 쪽에서 UID를 nullable = false 로 되어있는 상태에 test 코드를 구현하여, drop 하고 다시 생성하였더니 nullable = true로 반영되어 test가 통과되었습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지
* MemberInfo를 VO로 구현하여 MemberInfoVO 생성자를 만들어서 Info 값들을 따로 가져와서 구현하였습니다.
* role, ageRange, gender 은 enum 타입으로 하여 value.of 메소드를 이용하여 dto에 있는 값들을 가져왔습니다.
---

# 관련 스크린샷

---
<img width="1208" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/32f8f341-dfff-42c6-aaf3-1f0b26c10201">

![image](https://github.com/SpineTracker60/back-end/assets/122511826/740d3919-de2b-4fc4-9241-8a2e1f2a859d)

---

# 테스트 계획 또는 완료 사항
* Local 테스트 완료
* 추후 Social 테스트도 구현할 예정입니다.
---
