### PR TITLE
[Closes #37] Feat : DELETE APPLICATION SERVICE 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoController.java
@@ -1,0 +1,58 @@
+package com.spinetracker.spinetracker.domain.member.command.application.controller;
+
+import com.spinetracker.spinetracker.domain.member.command.application.dto.MemberInfoDTO;
+import com.spinetracker.spinetracker.domain.member.command.application.service.CreateMemberInfoService;
+import com.spinetracker.spinetracker.domain.member.command.application.service.UpdateMemberInfoService;
+import com.spinetracker.spinetracker.global.common.response.ResponseDTO;
+import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/member/info")
+public class MemberInfoController {
+
+    private final CreateMemberInfoService createMemberInfoService;
+    private final UpdateMemberInfoService updateMemberInfoService;
+    @Autowired
+    public MemberInfoController(CreateMemberInfoService createMemberInfoService, UpdateMemberInfoService updateMemberInfoService) {
+        this.createMemberInfoService = createMemberInfoService;
+        this.updateMemberInfoService = updateMemberInfoService;
+    }
+
+    // 회원가입시 사용자 정보 추가
+    @PostMapping("/")
+    public ResponseEntity<ResponseDTO> createMemberInfo(@RequestBody MemberInfoDTO memberInfoDTO, @CurrentMember UserPrincipal userPrincipal) {
+
+        Long memberId = userPrincipal.getId();
+
+        if (memberInfoDTO.getGender() == null || memberInfoDTO.getBirthdate() == null || memberInfoDTO.getJob() == null) {
+            throw new RuntimeException("정보를 모두 입력해야 합니다.");
+        }
+
+        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.CREATED, "추가 성공!!", createMemberInfoService.createMemberInfo(memberInfoDTO,memberId)));
+    }
+
+    // 마이페이지에서 사용자 정보 수정
+    @PutMapping("/")
+    public ResponseEntity<ResponseDTO> updateMemberInfo(@RequestBody MemberInfoDTO memberInfoDTO, @CurrentMember UserPrincipal userPrincipal) {
+
+        Long memberId = userPrincipal.getId();
+
+        if (memberInfoDTO.getGender() == null || memberInfoDTO.getBirthdate() == null || memberInfoDTO.getJob() == null) {
+            throw new RuntimeException("정보를 모두 입력해야 합니다.");
+        }
+
+        return ResponseEntity.ok().body(new ResponseDTO(HttpStatus.OK, "변경 성공!!", updateMemberInfoService.updateMemberInfo(memberInfoDTO,memberId)));
+    }
+
+
+
+    // 회원 탈퇴
+//    @DeleteMapping("/")
+
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/CreateMemberService.java
@@ -13,12 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class CreateMemberService {
 
     private final MemberRepository memberRepository;
-    private final RequestChatroom requestChatroom;
+//    private final RequestChatroom requestChatroom;
 
     @Autowired
-    public CreateMemberService(MemberRepository memberRepository, RequestChatroom requestChatroom) {
+    public CreateMemberService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
-        this.requestChatroom = requestChatroom;
+//        this.requestChatroom = requestChatroom;
     }
 
     // 소셜 로그인 시

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/DeleteMemberService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/service/DeleteMemberService.java
@@ -1,0 +1,37 @@
+package com.spinetracker.spinetracker.domain.member.command.application.service;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+import com.spinetracker.spinetracker.domain.member.command.domain.repository.MemberRepository;
+import com.spinetracker.spinetracker.domain.member.command.domain.service.RequestUnlinkMember;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class DeleteMemberService {
+
+    private MemberRepository memberRepository;
+
+    private RequestUnlinkMember requestUnlinkMember;
+
+    @Autowired
+    public DeleteMemberService(MemberRepository memberRepository, RequestUnlinkMember requestUnlinkMember) {
+        this.memberRepository = memberRepository;
+        this.requestUnlinkMember = requestUnlinkMember;
+    }
+
+    @Transactional
+    public boolean delete(Long memberId) {
+
+        Optional<Member> member = memberRepository.findById(memberId);
+        if(member.isPresent()) {
+            Member findMember = member.get();
+            boolean isSocialLoginUnlinked = requestUnlinkMember.unlinkSocial(findMember);
+            memberRepository.delete(findMember);
+            return isSocialLoginUnlinked;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/service/RequestUnlinkMember.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/domain/service/RequestUnlinkMember.java
@@ -1,0 +1,8 @@
+package com.spinetracker.spinetracker.domain.member.command.domain.service;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+
+public interface RequestUnlinkMember {
+
+    boolean unlinkSocial(Member member);
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/infra/KakaoUnlinkResponse.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/infra/KakaoUnlinkResponse.java
@@ -1,0 +1,15 @@
+package com.spinetracker.spinetracker.domain.member.command.infra;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class KakaoUnlinkResponse {
+
+    private Long id;
+
+    public KakaoUnlinkResponse() {}
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/infra/service/RequestUnlinkMemberImpl.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/infra/service/RequestUnlinkMemberImpl.java
@@ -1,0 +1,31 @@
+package com.spinetracker.spinetracker.domain.member.command.infra.service;
+
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+import com.spinetracker.spinetracker.domain.member.command.domain.service.RequestUnlinkMember;
+import com.spinetracker.spinetracker.global.common.annotation.InfraService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@InfraService
+public class RequestUnlinkMemberImpl implements RequestUnlinkMember {
+
+    private final UnlinkKakao unlinkKakao;
+//    private final UnlinkGoogle unlinkGoogle;
+
+    @Autowired
+    public RequestUnlinkMemberImpl(UnlinkKakao unlinkKakao) {
+        this.unlinkKakao = unlinkKakao;
+//        this.unlinkGoogle = unlinkGoogle;
+    }
+
+    @Override
+    public boolean unlinkSocial(Member member) {
+        if (member.getPlatform().name().equals("KAKAO")) {
+            return unlinkKakao.unlink(member.getUID());
+//        } else if (member.getPlatform().name().equals("GOOGLE")) {
+//            return unlinkGoogle.unlink(member.getUID());
+        }
+
+
+        return false;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/infra/service/UnlinkKakao.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/infra/service/UnlinkKakao.java
@@ -1,0 +1,55 @@
+package com.spinetracker.spinetracker.domain.member.command.infra.service;
+
+import com.spinetracker.spinetracker.domain.member.command.infra.KakaoUnlinkResponse;
+import com.spinetracker.spinetracker.global.common.annotation.InfraService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+
+@InfraService
+public class UnlinkKakao {
+
+    @Value("${app.auth.kakao-admin-key}")
+    private String KAKAO_ACCESS_TOKEN;
+    private final WebClient webClient;
+    public UnlinkKakao() {
+        DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory("https://kapi.kakao.com/v1/user/unlink");
+        webClient = WebClient.builder().uriBuilderFactory(uriBuilderFactory).baseUrl("https://kapi.kakao.com/v1/user/unlink").build();
+    }
+
+
+    public boolean unlink(String memberUid) {
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("target_id_type", "user_id");
+        formData.add("target_id", memberUid);
+
+        Mono<KakaoUnlinkResponse> response = webClient.post()
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .header("Authorization", "KakaoAK " + KAKAO_ACCESS_TOKEN)
+                .body(BodyInserters.fromFormData(formData))
+                .exchangeToMono(response1 -> {
+                    if (response1.statusCode().is2xxSuccessful()) {
+                        return response1.bodyToMono(KakaoUnlinkResponse.class);
+                    } else {
+                        return response1.createException().flatMap(Mono::error);
+                    }
+                });
+
+        if (Objects.requireNonNull(response.block()).getId() != null ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+}

--- a/src/main/java/com/spinetracker/spinetracker/global/common/response/ResponseDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/common/response/ResponseDTO.java
@@ -1,0 +1,51 @@
+package com.spinetracker.spinetracker.global.common.response;
+
+import org.springframework.http.HttpStatus;
+
+public class ResponseDTO {
+
+    private int status;
+    private String message;
+    private Object data;
+
+    public ResponseDTO () {}
+
+    public ResponseDTO(HttpStatus status, String message, Object data) {
+        this.status = status.value();
+        this.message = message;
+        this.data = data;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return "ResponseDTO{" +
+                "status=" + status +
+                ", message='" + message + '\'' +
+                ", data=" + data +
+                '}';
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/global/security/command/application/controller/AuthController.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/security/command/application/controller/AuthController.java
@@ -26,6 +26,7 @@ public class AuthController {
 
         Map<String, String> responseBody = new HashMap<>();
         responseBody.put("name", userPrincipal.getName());
+        responseBody.put("role", userPrincipal.getRole());
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 }

--- a/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/service/DeleteMemberServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/service/DeleteMemberServiceTest.java
@@ -1,0 +1,40 @@
+package com.spinetracker.spinetracker.domain.member.command.application.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class DeleteMemberServiceTest {
+
+    @Autowired
+    private DeleteMemberService deleteMemberService;
+
+    private static Stream<Arguments> getDeleteMemberInfo() {
+        return Stream.of(
+                Arguments.of(
+                    2L
+                )
+        );
+    }
+
+    @DisplayName("member가 회원탈퇴 되는지 확인")
+    @ParameterizedTest
+    @MethodSource("getDeleteMemberInfo")
+    void deleteMember(Long memberId) {
+
+        Assertions.assertDoesNotThrow(
+                () -> deleteMemberService.delete(memberId)
+        );
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #37 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* KAKAO_ACCESS_TOKEN을 이용하여 회원 탈퇴를 구현하였습니다. 
* Kakao Developers 홈페이지를 참고하여 헤더와 바디에 필요한 값들을 담아 카카오에서 제공하는 responsebody인 id를 리턴하게 구현하였습니다.
* 해당 회원의 플랫폼이 카카오면 회원의 UID를 가지고 오게 구현하였습니다.
---

# 관련 스크린샷

---
<img width="341" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/1a696499-c7fd-47f8-a03d-602c9dd31fbc">

---

# 테스트 계획 또는 완료 사항

---
* 카카오 member가 회원탈퇴 되는지 확인 테스트 완료하였습니다.