### PR TITLE
[Closes #56] FEAT : MEMBER 관련 CONTROLLER TEST 완료

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberController.java
@@ -2,7 +2,6 @@ package com.spinetracker.spinetracker.domain.member.command.application.controll
 
 import com.spinetracker.spinetracker.domain.member.command.application.service.DeleteMemberService;
 import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
-import com.spinetracker.spinetracker.global.common.response.ResponseDTO;
 import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberController.java
@@ -22,8 +22,8 @@ public class MemberController {
     }
 
     // 회원 탈퇴
-    @DeleteMapping("/")
-    public ResponseEntity<ResponseDTO> deleteMemberInfo(@CurrentMember UserPrincipal userPrincipal) {
+    @DeleteMapping
+    public ResponseEntity<Void> deleteMemberInfo(@CurrentMember UserPrincipal userPrincipal) {
 
         Long memberId = userPrincipal.getId();
 

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoController.java
@@ -2,7 +2,6 @@ package com.spinetracker.spinetracker.domain.member.command.application.controll
 
 import com.spinetracker.spinetracker.domain.member.command.application.dto.MemberInfoDTO;
 import com.spinetracker.spinetracker.domain.member.command.application.service.CreateMemberInfoService;
-import com.spinetracker.spinetracker.domain.member.command.application.service.DeleteMemberService;
 import com.spinetracker.spinetracker.domain.member.command.application.service.UpdateMemberInfoService;
 import com.spinetracker.spinetracker.global.common.response.ResponseDTO;
 import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
@@ -28,7 +27,7 @@ public class MemberInfoController {
     }
 
     // 회원가입시 사용자 정보 추가
-    @PostMapping("/")
+    @PostMapping
     public ResponseEntity<ResponseDTO> createMemberInfo(@RequestBody MemberInfoDTO memberInfoDTO, @CurrentMember UserPrincipal userPrincipal) {
 
         Long memberId = userPrincipal.getId();
@@ -41,7 +40,7 @@ public class MemberInfoController {
     }
 
     // 마이페이지에서 사용자 정보 수정
-    @PutMapping("/")
+    @PutMapping
     public ResponseEntity<ResponseDTO> updateMemberInfo(@RequestBody MemberInfoDTO memberInfoDTO, @CurrentMember UserPrincipal userPrincipal) {
 
         Long memberId = userPrincipal.getId();

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/MemberInfoDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/MemberInfoDTO.java
@@ -12,6 +12,8 @@ public class MemberInfoDTO {
     private LocalDate birthdate;
     private String job;
 
+    public MemberInfoDTO() {}
+
     public MemberInfoDTO(String gender, LocalDate birthdate, String job) {
         this.gender = gender;
         this.birthdate = birthdate;

--- a/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberControllerTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberControllerTest.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
-import com.spinetracker.spinetracker.domain.member.command.domain.repository.MemberRepository;
 import com.spinetracker.spinetracker.domain.member.command.domain.service.RequestUnlinkMember;
-import com.spinetracker.spinetracker.domain.member.query.application.service.FindMemberService;
 import com.spinetracker.spinetracker.global.common.WithMockCustomUser;
 import com.spinetracker.spinetracker.global.filter.TokenAuthenticationFilter;
 import com.spinetracker.spinetracker.global.security.command.application.service.CustomUserDetailService;
@@ -23,6 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 
@@ -34,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 class MemberControllerTest {
 
     @Autowired

--- a/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberControllerTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberControllerTest.java
@@ -1,0 +1,99 @@
+package com.spinetracker.spinetracker.domain.member.command.application.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.Member;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.repository.MemberRepository;
+import com.spinetracker.spinetracker.domain.member.command.domain.service.RequestUnlinkMember;
+import com.spinetracker.spinetracker.domain.member.query.application.service.FindMemberService;
+import com.spinetracker.spinetracker.global.common.WithMockCustomUser;
+import com.spinetracker.spinetracker.global.filter.TokenAuthenticationFilter;
+import com.spinetracker.spinetracker.global.security.command.application.service.CustomUserDetailService;
+import com.spinetracker.spinetracker.global.security.command.domain.service.CustomTokenService;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @Autowired
+    private CustomUserDetailService customUserDetailService;
+
+    @MockBean
+    private RequestUnlinkMember requestUnlinkMember;
+
+    @BeforeEach
+    public void setup() {
+
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .addFilter(new TokenAuthenticationFilter(customTokenService, customUserDetailService))
+                .build();
+
+    }
+    @Test
+    @DisplayName("사용자 정보 삭제 테스트")
+    @WithMockCustomUser(id = "2",email = "email@test.com", role = "MEMBER")
+    void deleteMember() throws Exception {
+
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String testToken = customTokenService.createToken(userPrincipal.getId(), userPrincipal.getRole());
+
+        Long memberId = userPrincipal.getId();
+        Member mockFindMember = new Member(
+                "email@test.com",
+                "효정",
+                "12423!",
+                "profileImage",
+                RoleEnum.MEMBER,
+                PlatformEnum.KAKAO
+        );
+
+        if(requestUnlinkMember.unlinkSocial(mockFindMember)) {
+            mockMvc.perform(
+                            delete("/member")
+                                    .header("Authorization", "Bearer " + testToken)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON)
+                                    .characterEncoding("utf-8")
+                    )
+                    .andDo(print())
+                    .andExpect(
+                            status().isNoContent()
+                    );
+        }
+    }
+}

--- a/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoControllerTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoControllerTest.java
@@ -1,0 +1,160 @@
+package com.spinetracker.spinetracker.domain.member.command.application.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spinetracker.spinetracker.domain.member.command.application.dto.MemberInfoDTO;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.AgeRangeEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.GenderEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
+import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
+import com.spinetracker.spinetracker.domain.member.query.application.dto.FindMemberDTO;
+import com.spinetracker.spinetracker.domain.member.query.application.service.FindMemberService;
+import com.spinetracker.spinetracker.global.common.WithMockCustomUser;
+import com.spinetracker.spinetracker.global.filter.TokenAuthenticationFilter;
+import com.spinetracker.spinetracker.global.security.command.application.service.CustomUserDetailService;
+import com.spinetracker.spinetracker.global.security.command.domain.service.CustomTokenService;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import java.time.LocalDate;
+import java.util.stream.Stream;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class MemberInfoControllerTest {
+
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    private FindMemberService findMemberService;
+
+    @Autowired
+    private CustomTokenService customTokenService;
+
+    @Autowired
+    private CustomUserDetailService customUserDetailService;
+
+    private static Stream<Arguments> saveMember() {
+        return Stream.of(
+                Arguments.of(
+                        new MemberInfoDTO(
+                        "FEMALE",
+                        LocalDate.parse("1995-06-04"),
+                        "학생"
+
+                        )));
+    }
+    @BeforeEach
+    public void setup() {
+
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .addFilter(new TokenAuthenticationFilter(customTokenService, customUserDetailService))
+                .build();
+
+    }
+    @ParameterizedTest(name="사용자 정보 추가 테스트")
+    @WithMockCustomUser(email = "email@test.com", role = "MEMBER")
+    @MethodSource("saveMember")
+    void addMemberInfo(MemberInfoDTO memberInfoDTO) throws Exception {
+
+        // 사용자 정보 토큰 생성
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String testToken = customTokenService.createToken(userPrincipal.getId(), userPrincipal.getRole());
+
+        Long memberId = userPrincipal.getId();
+
+        FindMemberDTO mockFindMemberDTO = new FindMemberDTO(
+                0L,
+                "mockName",
+                GenderEnum.FEMALE.name(),
+                AgeRangeEnum.FIFTY.name(),
+                "학생",
+                "profileImage",
+                PlatformEnum.KAKAO.name(),
+                RoleEnum.MEMBER.name(),
+                "email@test.com"
+        );
+        when(findMemberService.findById(memberId)).thenReturn(mockFindMemberDTO);
+
+        String content = objectMapper.writeValueAsString(memberInfoDTO);
+        mockMvc.perform(
+                        post("/member/info")
+                                .header("Authorization", "Bearer " + testToken)
+                                .content(content)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                )
+                .andDo(print())
+                .andExpect(
+                        status().isCreated()
+                );
+    }
+
+    @ParameterizedTest(name="사용자 정보 수정 테스트")
+    @WithMockCustomUser(email = "email@test.com", role = "MEMBER")
+    @MethodSource("saveMember")
+    void updateMemberInfo(MemberInfoDTO memberInfoDTO) throws Exception {
+
+        // 사용자 정보 토큰 생성
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String testToken = customTokenService.createToken(userPrincipal.getId(), userPrincipal.getRole());
+
+        Long memberId = userPrincipal.getId();
+
+        FindMemberDTO mockFindMemberDTO = new FindMemberDTO(
+                0L,
+                "mockName",
+                GenderEnum.FEMALE.name(),
+                AgeRangeEnum.FIFTY.name(),
+                "학생",
+                "profileImage",
+                PlatformEnum.KAKAO.name(),
+                RoleEnum.MEMBER.name(),
+                "email@test.com"
+        );
+        when(findMemberService.findById(memberId)).thenReturn(mockFindMemberDTO);
+
+        String content = objectMapper.writeValueAsString(memberInfoDTO);
+        mockMvc.perform(
+                        put("/member/info")
+                                .header("Authorization", "Bearer " + testToken)
+                                .content(content)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .characterEncoding("utf-8")
+                )
+                .andDo(print())
+                .andExpect(
+                        status().isOk()
+                );
+    }
+}

--- a/src/test/java/com/spinetracker/spinetracker/global/common/WithMockCustomUser.java
+++ b/src/test/java/com/spinetracker/spinetracker/global/common/WithMockCustomUser.java
@@ -1,7 +1,5 @@
 package com.spinetracker.spinetracker.global.common;
 
-import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
-import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
 import org.springframework.security.test.context.support.WithSecurityContext;
 
 import java.lang.annotation.Retention;
@@ -11,6 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 @WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
 public @interface WithMockCustomUser {
 
+    String id() default "0";
     String email() default "first";
     String role() default "MEMBER";
     String provider() default "GOOGLE";

--- a/src/test/java/com/spinetracker/spinetracker/global/common/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/spinetracker/spinetracker/global/common/WithMockCustomUserSecurityContextFactory.java
@@ -2,11 +2,8 @@ package com.spinetracker.spinetracker.global.common;
 
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.AgeRangeEnum;
 import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.GenderEnum;
-import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.PlatformEnum;
-import com.spinetracker.spinetracker.domain.member.command.domain.aggregate.entity.enumtype.RoleEnum;
 import com.spinetracker.spinetracker.domain.member.query.application.dto.FindMemberDTO;
 import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
-import org.apache.catalina.User;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -19,7 +16,7 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
         SecurityContext context = SecurityContextHolder.createEmptyContext();
 
         FindMemberDTO mockFindMemberDTO = new FindMemberDTO(
-                0L,
+                Long.parseLong(annotation.id()),
                 "mockName",
                 GenderEnum.FEMALE.name(),
                 AgeRangeEnum.FIFTY.name(),


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #56 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 사용자 삭제 테스트를 할 때 when - thenReturn으로 구현하였더니 controller에서 service로 넘어가는 메소드가 실행되지 않고, httpStatus가 200으로 뜨는 문제가 발생했는데, if문으로 간결하게 해결하였더니 성공하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* mock으로 테스트하여 임의의 값을 WithMockCustomUser로 줘서 테스트 하였습니다.
---

# 관련 스크린샷

---
<img width="379" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/663c86a3-2cf5-49df-b049-0d674c203326">
<img width="335" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/d21b6fd2-05d7-41e9-b512-6b2322cc78d4">

---

# 테스트 계획 또는 완료 사항

---
* 사용자 정보 추가 테스트, 사용자 정보 수정 테스트, 사용자 정보 삭제 테스트를 완료하였습니다.
