### PR TITLE
[#closes 53] : Feat : springdoc을 통한 Swagger 3.0 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.3.1'
+    implementation 'org.testng:testng:7.1.0'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -43,6 +44,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
+
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.6'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-security', version: '1.6.4'
+    testImplementation group: 'org.springdoc', name: 'springdoc-openapi-webmvc-core', version: '1.6.4'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/controller/CreatePostureController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/controller/CreatePostureController.java
@@ -1,6 +1,5 @@
 package com.spinetracker.spinetracker.domain.posture.command.application.controller;
 
-import com.spinetracker.spinetracker.domain.chatroom.command.infra.response.Response;
 import com.spinetracker.spinetracker.domain.posture.command.application.dto.CreatePostureLogDTO;
 import com.spinetracker.spinetracker.domain.posture.command.application.dto.PostureBody;
 import com.spinetracker.spinetracker.domain.posture.command.application.dto.ResponsePosture;
@@ -8,17 +7,25 @@ import com.spinetracker.spinetracker.domain.posture.command.application.service.
 import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.entity.PostureLog;
 import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
 import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+@Tag(name = "PostureLog", description = "자세 기록 API")
 @RestController
 @RequestMapping("/posture")
 public class CreatePostureController {
@@ -30,8 +37,21 @@ public class CreatePostureController {
         this.createPostureLogService = createPostureLogService;
     }
 
-    @PostMapping
-    public ResponseEntity<ResponsePosture> create(@RequestBody List<CreatePostureLogDTO> createPostureLogDTOList, @CurrentMember UserPrincipal userPrincipal) {
+    // 메서드 정보
+    @Operation(
+            summary = "자세 기록 생성",
+            description = "토큰을 기반으로 사용자의 새로운 자세 트래킹 정보를 셍성합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ResponsePosture.class))}),
+            //@ApiResponse(code = 204, message = "member not exists"),
+    })
+    @PostMapping("/")
+    public ResponseEntity<ResponsePosture> create(
+            @RequestBody List<CreatePostureLogDTO> createPostureLogDTOList,
+            @CurrentMember UserPrincipal userPrincipal
+    ) {
 
         Long memberId = userPrincipal.getId();
         List<PostureLog> createdPostureLogList = new ArrayList<>();

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/CreatePostureLogDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/CreatePostureLogDTO.java
@@ -1,9 +1,12 @@
 package com.spinetracker.spinetracker.domain.posture.command.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -11,11 +14,26 @@ import java.time.LocalTime;
 @Setter
 public class CreatePostureLogDTO {
 
+    @Schema(type = "String", example = "TEXTNECK", description="자세 태그 입니다.", allowableValues={"TEXTNECK", "ASYMMETRY", "STOOPED", "SLEEPINESS", "START", "END"})
+    @NotBlank
+    @NotNull
     @JsonProperty("posture_tag")
     private String postureTag;
+
+    @Schema(type = "String", example = "2023-09-18", description="한 자세 태그의 생성 일자 입니다." )
+    @NotBlank
+    @NotNull
     private LocalDate date;
+
+    @Schema(type = "String", example = "12:00:00", description="한 자세 태그의 시작 시간 입니다." )
+    @NotBlank
+    @NotNull
     @JsonProperty("start_time")
     private LocalTime startTime;
+
+    @Schema(type = "String", example = "12:00:00", description="한 자세 태그의 종료 시간 입니다." )
+    @NotBlank
+    @NotNull
     @JsonProperty("end_time")
     private LocalTime endTime;
 

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/PostureBody.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/PostureBody.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -23,16 +24,20 @@ import java.time.LocalTime;
 public class PostureBody implements Serializable {
     private Long memberId;
     @JsonProperty("posture_tag")
+    @Schema(type = "String", example = "TEXTNECK", description="자세 태그 입니다.", allowableValues={"TEXTNECK", "ASYMMETRY", "STOOPED", "SLEEPINESS", "START", "END"})
     private String postureTag;
 
+    @Schema(type = "String", example = "2023-09-18", description="한 자세 태그의 생성 일자 입니다." )
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone="Asia/Seoul")
     private LocalDate date;
 
     @JsonProperty("start_time")
+    @Schema(type = "String", example = "12:00:00", description="한 자세 태그의 시작 시간 입니다." )
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone="Asia/Seoul")
     private LocalTime startTime;
 
     @JsonProperty("end_time")
+    @Schema(type = "String", example = "12:00:00", description="한 자세 태그의 종료 시간 입니다." )
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss", timezone="Asia/Seoul")
     private LocalTime endTime;
 

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
@@ -86,8 +86,11 @@ public class SecurityConfiguration {
                                         "/**/*.html", "/**/*.css", "/**/*.js"
                                 )
                                 .antMatchers(
-                                        "/swagger", "/swagger-ui.html", "/swagger-ui/**",
-                                        "/api-docs", "/api-docs/**", "/v3/api-docs/**"
+                                        "/api-docs",
+                                        "/v2/api-docs",  "/v3/api-docs","/configuration/ui",
+                                        "/swagger-resources/**", "/configuration/security",
+                                        "/swagger-ui.html", "/webjars/**","/swagger/**",
+                                        "/swagger-ui/**", "/swagger","/webjars/**"
                                 )
                                 .antMatchers(
                                         "/login/**"

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SwaggerConfiguration.java
@@ -1,0 +1,38 @@
+package com.spinetracker.spinetracker.global.configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfiguration {
+    private final String securitySchemeName = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI(@Value("${springdoc.version}") String appVersion) {
+        Info info = new Info().title("SpineTracker REST API Document").version(appVersion)
+                .description("Spring Boot를 이용한 SpineTracker 웹 애플리케이션 API 도큐먼트입니다.")
+                .termsOfService("http://swagger.io/terms/")
+                .contact(new Contact().name("JIWON").url("https://github.com/jiwon11").email("jeewonre@gmail.com"))
+                .contact(new Contact().name("namhyojeong").url("https://github.com/namhyojeong").email("namgywjd2@gmail.com"))
+                .license(new License().name("Apache License Version 2.0").url("http://www.apache.org/licenses/LICENSE-2.0"));
+
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components().addSecuritySchemes(securitySchemeName,
+                        new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                ))
+                .info(info);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/global/docs/controller/SwaggerRedirector.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/docs/controller/SwaggerRedirector.java
@@ -1,0 +1,12 @@
+package com.spinetracker.spinetracker.global.docs.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/docs")
+class SwaggerRedirector {
+    @GetMapping
+    public String api() { return "redirect:/swagger-ui/index.html"; }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #53 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* springdoc 라이브러리를 사용하여 Swagger 3.0 을 연결하였습니다.
* Swagger 3.0 을 컨트롤러에서 사용하기 위한 예시로 `CreatePostureController`의 `POST /posture` API 에 관련 코드를 추가하였습니다.
---

# 관련 스크린샷

<img width="757" alt="CleanShot 2023-09-19 at 17 08 59@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/32cce05c-a28c-42e7-8665-3ee5ab9e9441">

---
* ` /api-docs` 을 검색하여 저희 도큐먼트를 확인할 수 있습니다.
---

# 테스트 계획 또는 완료 사항

---
* 없음
