### PR TITLE
[Closes #59] : Feat : 오늘의 자세 기록에 대한 Summary 조회 기능 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/controller/FindDailyPostureController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/controller/FindDailyPostureController.java
@@ -1,0 +1,45 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.controller;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.DailyPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.service.FindDailyPostureLogService;
+import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name = "PostureLog", description = "자세 기록 API")
+@RestController
+@RequestMapping("/posture")
+public class FindDailyPostureController {
+
+    private final FindDailyPostureLogService findDailyPostureLogService;
+
+    @Autowired
+    public FindDailyPostureController(FindDailyPostureLogService findDailyPostureLogService) {
+        this.findDailyPostureLogService = findDailyPostureLogService;
+    }
+
+    @Operation(
+            summary = "오늘의 자세 기록 Summary 조회",
+            description = "토큰을 기반으로 사용자의 오늘의 자세 기록 Summary를 조회합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = DailyPostureLogDTO.class))}),
+            //@ApiResponse(code = 204, message = "member not exists"),
+    })
+    @GetMapping("/daily")
+    public ResponseEntity<DailyPostureLogDTO> getDailyPostureLog(@CurrentMember UserPrincipal userPrincipal) {
+        Long memberId = userPrincipal.getId();
+        DailyPostureLogDTO dailyPostureLogDTO = findDailyPostureLogService.getSummary(memberId);
+        return ResponseEntity.ok(dailyPostureLogDTO);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/DailyPostureLogDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/DailyPostureLogDTO.java
@@ -1,0 +1,54 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.Map;
+
+@JsonPropertyOrder({ "focus_time", "unstable_time", "count_sleep", "count_warn", "posture_time" })
+public class DailyPostureLogDTO implements Serializable {
+
+    @JsonProperty("focus_time")
+    @Schema(type = "Integer", example = "7200", description="일간 집중 시간입니다. (단위 : 초)")
+    private Integer focusTime;
+
+    @JsonProperty("unstable_time")
+    @Schema(type = "Integer", example = "541", description="일간 불안정 자세입니다. (단위 : 초)")
+    private Integer unstableTime;
+
+    @JsonProperty("count_sleep")
+    @Schema(type = "Integer", example = "4", description="일간 졸음 횟수입니다. (단위 : 회)")
+    private Integer CountSleep;
+
+    @JsonProperty("count_warn")
+    @Schema(type = "Integer", example = "5", description="일간 경고 횟수입니다. (단위 : 회)")
+    private Integer CountWarn;
+
+    @JsonProperty("posture_time")
+    @Schema(type = "Object", ref = "#/components/schemas/PostureTime")
+    private Map<String, Integer> postureTime;
+
+    protected DailyPostureLogDTO() {}
+
+    public DailyPostureLogDTO(Integer focusTime, Integer unstableTime, Integer countSleep, Integer countWarn, Map<String, Integer> postureTime) {
+        this.focusTime = focusTime;
+        this.unstableTime = unstableTime;
+        this.CountSleep = countSleep;
+        this.CountWarn = countWarn;
+        this.postureTime = postureTime;
+    }
+
+    @Override
+    public String toString() {
+        return "DailyPostureLogDTO{" +
+                "focusTime=" + focusTime +
+                ", unstableTime=" + unstableTime +
+                ", CountSleep=" + CountSleep +
+                ", CountWarn=" + CountWarn +
+                ", postureTime=" + postureTime +
+                '}';
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/FindPostureLogDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/FindPostureLogDTO.java
@@ -1,0 +1,37 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class FindPostureLogDTO {
+    private Long id;
+    private String postureTag;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    protected FindPostureLogDTO() {}
+
+    public FindPostureLogDTO(Long id, String postureTag, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        this.id = id;
+        this.postureTag = postureTag;
+        this.date = date;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    @Override
+    public String toString() {
+        return "FindPostureLogDTO{" +
+                "id=" + id +
+                ", postureTag='" + postureTag + '\'' +
+                ", date=" + date +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                '}';
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindDailyPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindDailyPostureLogService.java
@@ -1,0 +1,28 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.service;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.DailyPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.domain.service.CalcDailyPostureLogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FindDailyPostureLogService {
+
+
+    private final FindPostureLogService findPostureLogService;
+    private final CalcDailyPostureLogService calcDailyPostureLogService;
+
+    @Autowired
+    public FindDailyPostureLogService(FindPostureLogService findPostureLogService, CalcDailyPostureLogService calcDailyPostureLogService) {
+        this.findPostureLogService = findPostureLogService;
+        this.calcDailyPostureLogService = calcDailyPostureLogService;
+    }
+
+    public DailyPostureLogDTO getSummary(Long memberId) {
+        List<FindPostureLogDTO> todayPostureLogList = findPostureLogService.findByMemberId(memberId);
+        return calcDailyPostureLogService.calculate(todayPostureLogList);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindPostureLogService.java
@@ -1,0 +1,31 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.service;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.domain.repository.PostureLogMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class FindPostureLogService {
+
+    private final PostureLogMapper postureLogMapper;
+
+    @Autowired
+    public FindPostureLogService(PostureLogMapper postureLogMapper) {
+        this.postureLogMapper = postureLogMapper;
+    }
+
+    public List<FindPostureLogDTO> findByMemberId(Long memberId) {
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("memberId", memberId);
+        params.put("todayDate", LocalDate.now());
+
+        return postureLogMapper.findDailyPosture(params);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/repository/PostureLogMapper.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/repository/PostureLogMapper.java
@@ -1,0 +1,13 @@
+package com.spinetracker.spinetracker.domain.posture.query.domain.repository;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Map;
+
+@Mapper
+public interface PostureLogMapper {
+
+    List<FindPostureLogDTO> findDailyPosture(Map<String, Object> param);
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/service/CalcDailyPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/service/CalcDailyPostureLogService.java
@@ -1,0 +1,59 @@
+package com.spinetracker.spinetracker.domain.posture.query.domain.service;
+
+import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.enumtype.PostureTag;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.DailyPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import com.spinetracker.spinetracker.global.common.annotation.DomainService;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@DomainService
+public class CalcDailyPostureLogService {
+
+    public DailyPostureLogDTO calculate(List<FindPostureLogDTO> findPostureLogDTOList) {
+
+        int focusTime = 0;
+        int unstableTime = 0;
+        int CountSleep = 0;
+        int CountWarn = 0;
+        Map<String, Integer> postureTime = new HashMap<>();
+        for(PostureTag tag : PostureTag.values()) {
+            if (!tag.name().equals("START") && !tag.name().equals("END")) {
+                postureTime.putIfAbsent(tag.name(), 0);
+            }
+        }
+
+
+        LocalTime startTime = null;
+        LocalTime endTime = null;
+        if(!findPostureLogDTOList.isEmpty()) {
+            for(FindPostureLogDTO findPostureLogDTO : findPostureLogDTOList) {
+                if(findPostureLogDTO.getPostureTag().equals("START") || findPostureLogDTO.getPostureTag().equals("END")) {
+                    if(findPostureLogDTO.getPostureTag().equals("START")) {
+                        startTime = findPostureLogDTO.getStartTime();
+                    }
+                    else {
+                        endTime = findPostureLogDTO.getEndTime();
+                    }
+                } else {
+                    Duration duration = Duration.between(findPostureLogDTO.getStartTime(), findPostureLogDTO.getEndTime());
+                    int diffSec = (int) duration.getSeconds();
+                    unstableTime = unstableTime + diffSec;
+                    postureTime.put(findPostureLogDTO.getPostureTag(), postureTime.get(findPostureLogDTO.getPostureTag()) + diffSec);
+                    if (findPostureLogDTO.getPostureTag().equals("SLEEPINESS")) {
+                        CountSleep = CountSleep + 1;
+
+                    }
+                }
+            }
+            Duration duration = Duration.between(startTime, endTime);
+            focusTime = (int) duration.getSeconds();
+        }
+        return new DailyPostureLogDTO(focusTime, unstableTime, CountSleep, CountWarn, postureTime);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SwaggerConfiguration.java
@@ -5,11 +5,16 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
 
 @Configuration
 public class SwaggerConfiguration {
@@ -24,15 +29,27 @@ public class SwaggerConfiguration {
                 .contact(new Contact().name("namhyojeong").url("https://github.com/namhyojeong").email("namgywjd2@gmail.com"))
                 .license(new License().name("Apache License Version 2.0").url("http://www.apache.org/licenses/LICENSE-2.0"));
 
+
+        Schema postureTime = new Schema<Map<String, Object>>()
+                .addProperties("ASYMMETRY",new IntegerSchema().example(80))
+                .addProperties("TEXTNECK",new IntegerSchema().example(161))
+                .addProperties("STOOPED",new IntegerSchema().example(0))
+                .addProperties("SLEEPINESS",new IntegerSchema().example(300))
+                .description("일간 자세별 지속 시간 입니다. (단위 : 초)")
+        ;
+
         return new OpenAPI()
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
-                .components(new Components().addSecuritySchemes(securitySchemeName,
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
                         new SecurityScheme()
                                 .name(securitySchemeName)
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")
-                ))
+                    )
+                        .addSchemas("PostureTime", postureTime)
+                )
                 .info(info);
     }
 }

--- a/src/main/resources/mapper/postureLog/PostureLogMapper.xml
+++ b/src/main/resources/mapper/postureLog/PostureLogMapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.spinetracker.spinetracker.domain.posture.query.domain.repository.PostureLogMapper">
+    <resultMap id="PostureLogMap" type="com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO">
+        <id property="id" column="id" />
+        <result property="postureTag" column="posture_tag"/>
+        <result property="date" column="date" />
+        <result property="startTime" column="start_time" />
+        <result property="endTime" column="end_time" />
+    </resultMap>
+
+    <select id="findDailyPosture" resultMap="PostureLogMap" parameterType="Map">
+        SELECT *
+        FROM
+            POSTURE_LOG_TB
+        WHERE
+            member_id = #{memberId}
+        AND
+            date = #{todayDate}
+        ORDER BY
+            start_time ASC
+    </select>
+</mapper>

--- a/src/test/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindDailyPostureLogServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindDailyPostureLogServiceTest.java
@@ -1,0 +1,28 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class FindDailyPostureLogServiceTest {
+
+    @Autowired
+    private FindDailyPostureLogService findDailyPostureLogService;
+
+    @Test
+    @DisplayName("사용자 Id를 통해 오늘의 자세 요약 정보 확인 테스트")
+    void testGetSummary() {
+
+        Long memberId = 8L;
+        Assertions.assertDoesNotThrow(
+                () -> findDailyPostureLogService.getSummary(memberId)
+        );
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #59 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 오늘의 자세 기록에 대한 Summary 조회 기능 구현하였습니다.
* 사용자의 Id와 오늘 날짜를 파라미터로 받아 데이터베이스에서 자세 기록을 조회하는 Mybatis Mapper와 Interface를 구현하였습니다. 
* `query / domain / service ` 패키지에 CalcDailyPostureLogService 클래스를 통해 `List<FindPostureLogDTO>` 를 파라미터로 받아 일간 집중 시간, 일간 불안정 자체 총 시간, 일간 졸음 횟수, 일간 경고 횟수, 일간 자세별 지속 시간을 계산하는 도메인 클래스를 따로 구현하였습니다.
* Jackson 라이브러리를 이용하여 `DailyPostureLogDTO` 클래스를 JSON 구조로 변환하였습니다.
* `DailyPostureLogDTO`에서 Map 타입의 필드를 Swagger 예시로 보여주기 위해 커스텀 Schema 를 추가하였습니다.
---

# 관련 스크린샷

<img width="1491" alt="CleanShot 2023-09-19 at 22 52 36@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/4f0eaff4-5c5f-446b-8563-3a50a3470c36">

---
* 없음
---

# 테스트 계획 또는 완료 사항

<img width="885" alt="CleanShot 2023-09-19 at 21 59 28@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/cdcde7d8-46b1-4de2-8cf6-e860e91a1bc9">

---
* 사용자 Id를 통해 오늘의 자세 요약 정보를 확인하는 테스트를 진행하였습니다.
