### PR TITLE
[Closes #60] : Feat : 주간 자세 기록 대시보드 조회 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/controller/FindWeeklyPostureController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/controller/FindWeeklyPostureController.java
@@ -1,0 +1,51 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.controller;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.DailyPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.WeeklyDashBoardPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.service.DashboardPostureLogService;
+import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "PostureLog", description = "자세 기록 API")
+@RestController
+@RequestMapping("/posture")
+public class FindWeeklyPostureController {
+
+
+    private final DashboardPostureLogService dashboardPostureLogService;
+
+    @Autowired
+    public FindWeeklyPostureController(DashboardPostureLogService dashboardPostureLogService) {
+        this.dashboardPostureLogService = dashboardPostureLogService;
+    }
+
+
+    @Operation(
+            summary = "주간 자세 기록 Summary 조회",
+            description = "토큰을 기반으로 사용자의 주간 자세 기록 Summary를 조회합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = WeeklyDashBoardPostureLogDTO.class))}),
+            //@ApiResponse(code = 204, message = "member not exists"),
+    })
+    @GetMapping("/dashboard/weekly")
+    public ResponseEntity<List<WeeklyDashBoardPostureLogDTO>> getWeeklyPostureLog(@CurrentMember UserPrincipal userPrincipal) {
+        Long memberId = userPrincipal.getId();
+        List<WeeklyDashBoardPostureLogDTO> weeklyDashBoardPostureLogDTOList = dashboardPostureLogService.getWeeklyDashBoard(memberId);
+        return ResponseEntity.ok(weeklyDashBoardPostureLogDTOList);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/WeeklyDashBoardPostureLogDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/WeeklyDashBoardPostureLogDTO.java
@@ -1,0 +1,35 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class WeeklyDashBoardPostureLogDTO {
+
+    @Schema(type = "Date", example = "2023-09-21", description="이번 주에 속한 날짜 입니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone="Asia/Seoul")
+    private LocalDate date;
+    @JsonProperty("daily_posture_summary")
+    private DailyPostureLogDTO dailyPostureLogDTO;
+
+    public WeeklyDashBoardPostureLogDTO() {}
+
+    public WeeklyDashBoardPostureLogDTO(LocalDate date, DailyPostureLogDTO dailyPostureLogDTO) {
+        this.date = date;
+        this.dailyPostureLogDTO = dailyPostureLogDTO;
+    }
+
+    @Override
+    public String toString() {
+        return "WeeklyDashBoardPostureLogDTO{" +
+                "date=" + date +
+                ", dailyPostureLogDTO=" + dailyPostureLogDTO +
+                '}';
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/DashboardPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/DashboardPostureLogService.java
@@ -1,0 +1,28 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.service;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.WeeklyDashBoardPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.domain.service.CalcDashboardPostureLogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DashboardPostureLogService {
+
+    private final FindPostureLogService findPostureLogService;
+    private final CalcDashboardPostureLogService calcDashboardPostureLogService;
+
+    @Autowired
+    public DashboardPostureLogService(FindPostureLogService findPostureLogService, CalcDashboardPostureLogService calcDashboardPostureLogService) {
+        this.findPostureLogService = findPostureLogService;
+        this.calcDashboardPostureLogService = calcDashboardPostureLogService;
+    }
+
+    public List<WeeklyDashBoardPostureLogDTO> getWeeklyDashBoard(Long memberId) {
+        List<FindPostureLogDTO> weeklyPostureLogList = findPostureLogService.findWeeklyByMemberId(memberId);
+
+        return calcDashboardPostureLogService.calculate(weeklyPostureLogList);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindPostureLogService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoField;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,5 +28,24 @@ public class FindPostureLogService {
         params.put("todayDate", LocalDate.now());
 
         return postureLogMapper.findDailyPosture(params);
+    }
+
+    public List<FindPostureLogDTO> findWeeklyByMemberId(Long memberId) {
+
+        LocalDate today = LocalDate.now();
+
+        int day = today.get(ChronoField.DAY_OF_WEEK);
+        if (day == 7) {
+            day = 0;
+        }
+        LocalDate startDate = today.minusDays(day);
+        LocalDate endDate = startDate.plusDays(6);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("memberId", memberId);
+        params.put("startDate", startDate);
+        params.put("endDate", endDate);
+
+        return postureLogMapper.findWeekly(params);
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/PostureTimePerDate.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/PostureTimePerDate.java
@@ -1,0 +1,7 @@
+package com.spinetracker.spinetracker.domain.posture.query.domain;
+
+public class PostureTimePerDate {
+    private int focusTime;
+    private int TextNeckTime;
+    private int AsymmetryTime;
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/repository/PostureLogMapper.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/repository/PostureLogMapper.java
@@ -10,4 +10,6 @@ import java.util.Map;
 public interface PostureLogMapper {
 
     List<FindPostureLogDTO> findDailyPosture(Map<String, Object> param);
+
+    List<FindPostureLogDTO> findWeekly(Map<String, Object> params);
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/service/CalcDashboardPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/service/CalcDashboardPostureLogService.java
@@ -1,0 +1,48 @@
+package com.spinetracker.spinetracker.domain.posture.query.domain.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.DailyPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.WeeklyDashBoardPostureLogDTO;
+import com.spinetracker.spinetracker.global.common.annotation.DomainService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@DomainService
+public class CalcDashboardPostureLogService {
+
+    private final CalcDailyPostureLogService calcDailyPostureLogService;
+
+    @Autowired
+    public CalcDashboardPostureLogService(CalcDailyPostureLogService calcDailyPostureLogService) {
+        this.calcDailyPostureLogService = calcDailyPostureLogService;
+    }
+
+    public List<WeeklyDashBoardPostureLogDTO> calculate(List<FindPostureLogDTO> findPostureLogDTOList) {
+        List<WeeklyDashBoardPostureLogDTO> weeklyDashBoardPostureLogDTOList = new ArrayList<>();
+        Map<LocalDate, List<FindPostureLogDTO>> findPostureLogDTOListPerDate = new HashMap<>();
+
+        if(!findPostureLogDTOList.isEmpty()) {
+            for(FindPostureLogDTO findPostureLogDTO: findPostureLogDTOList) {
+                findPostureLogDTOListPerDate.putIfAbsent(findPostureLogDTO.getDate(), new ArrayList<>());
+                findPostureLogDTOListPerDate.get(findPostureLogDTO.getDate()).add(findPostureLogDTO);
+            }
+        }
+        
+        for (LocalDate date: findPostureLogDTOListPerDate.keySet()) {
+            WeeklyDashBoardPostureLogDTO weeklyDashBoardPostureLogDTO = new WeeklyDashBoardPostureLogDTO(
+                    date,
+                    calcDailyPostureLogService.calculate(findPostureLogDTOListPerDate.get(date))
+            );
+
+            weeklyDashBoardPostureLogDTOList.add(weeklyDashBoardPostureLogDTO);
+        }
+
+        return weeklyDashBoardPostureLogDTOList;
+    }
+}

--- a/src/main/resources/mapper/postureLog/PostureLogMapper.xml
+++ b/src/main/resources/mapper/postureLog/PostureLogMapper.xml
@@ -18,6 +18,22 @@
         AND
             date = #{todayDate}
         ORDER BY
-            start_time ASC
+            start_time
+    </select>
+
+    <select id="findWeekly" resultMap="PostureLogMap" parameterType="Map">
+        SELECT *
+        FROM
+            POSTURE_LOG_TB
+        WHERE
+            member_id = #{memberId}
+          AND
+            date
+                BETWEEN
+                    #{startDate}
+                AND
+                    #{endDate}
+        ORDER BY
+            start_time
     </select>
 </mapper>

--- a/src/test/java/com/spinetracker/spinetracker/domain/posture/query/application/service/DashboardPostureLogServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/posture/query/application/service/DashboardPostureLogServiceTest.java
@@ -1,0 +1,26 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class DashboardPostureLogServiceTest {
+
+    @Autowired
+    private DashboardPostureLogService dashboardPostureLogService;
+
+    @Test
+    @DisplayName("사용자 Id를 통해 주간 대시보드 조회 테스트")
+    void getWeeklyDashBoard() {
+
+        Long memberId = 8L;
+        System.out.println(dashboardPostureLogService.getWeeklyDashBoard(memberId));
+
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #60 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 오늘을 기준으로 이번주의 주간 자세 기록을 일별 Summary를 바탕으로 주간 대시보드 데이터를 조회합니다.
---

# 관련 스크린샷

<img width="1460" alt="CleanShot 2023-09-20 at 16 16 20@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/227f10c6-5e97-48b3-b712-24777b3480e5">

---
* 없음
---

# 테스트 계획 또는 완료 사항

<img width="942" alt="CleanShot 2023-09-20 at 16 16 43@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/a041344b-606f-4426-9c32-4abc7325a162">

---
* 사용자 Id를 통해 주간 대시보드를 조회하는 테스트를 진행하였습니다.
