### PR TITLE
[Closes #67] : Feat : 주간 불안정 자세 비율 계산 조회 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/controller/FindUnStableRatioPostureController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/controller/FindUnStableRatioPostureController.java
@@ -1,0 +1,47 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.controller;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.UnStableRatioDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.service.FindUnstableRatioPostureLogService;
+import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Tag(name = "PostureLog", description = "자세 기록 API")
+@RestController
+@RequestMapping("/posture")
+public class FindUnStableRatioPostureController {
+
+    private final FindUnstableRatioPostureLogService findUnstableRatioPostureLogService;
+
+    @Autowired
+    public FindUnStableRatioPostureController(FindUnstableRatioPostureLogService findUnstableRatioPostureLogService) {
+        this.findUnstableRatioPostureLogService = findUnstableRatioPostureLogService;
+    }
+
+    @Operation(
+            summary = "주간 불안정 자세 비율 조회",
+            description = "토큰을 기반으로 사용자의 주간 불안정 자세 비율을 조회합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UnStableRatioDTO.class))}),
+            //@ApiResponse(code = 204, message = "member not exists"),
+    })
+    @GetMapping("/ratio")
+    public ResponseEntity<UnStableRatioDTO> getWeeklyUnstablePostureLog(@RequestParam Long memberId) {
+        UnStableRatioDTO weeklyUnStableRatioDTO = findUnstableRatioPostureLogService.getUnStableRatio(memberId);
+        return ResponseEntity.ok(weeklyUnStableRatioDTO);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/UnStableRatioDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/dto/UnStableRatioDTO.java
@@ -1,0 +1,30 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.ToString;
+
+
+public class UnStableRatioDTO {
+
+    @JsonProperty("turtle_neck")
+    @Schema(type = "Double", example = "0.21", description="주간 불안정 자세 중 거북목 자세의 비율 입니다.")
+    private final Double textNeck;
+    @JsonProperty("asymmetry")
+    @Schema(type = "Double", example = "0.16", description="주간 불안정 자세 중 비대칭 자세의 비율 입니다.")
+    private final Double asymmetry;
+    @JsonProperty("stooped_position")
+    @Schema(type = "Double", example = "0.03", description="주간 불안정 자세 중 구부정 자세의 비율 입니다.")
+    private final Double stooped;
+    @JsonProperty("sleepiness")
+    @Schema(type = "Double", example = "0.6", description="주간 불안정 자세 중 졸음 자세의 비율 입니다.")
+    private final Double sleepiness;
+
+    public UnStableRatioDTO(Double textNeck, Double asymmetry, Double stooped, Double sleepiness) {
+        this.textNeck = textNeck;
+        this.asymmetry = asymmetry;
+        this.stooped = stooped;
+        this.sleepiness = sleepiness;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindUnstableRatioPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/application/service/FindUnstableRatioPostureLogService.java
@@ -1,0 +1,27 @@
+package com.spinetracker.spinetracker.domain.posture.query.application.service;
+
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.UnStableRatioDTO;
+import com.spinetracker.spinetracker.domain.posture.query.domain.service.CalcUnStableRatioPostureLogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FindUnstableRatioPostureLogService {
+
+    private final FindPostureLogService findPostureLogService;
+    private final CalcUnStableRatioPostureLogService calcUnStableRatioPostureLogService;
+
+    @Autowired
+    public FindUnstableRatioPostureLogService(FindPostureLogService findPostureLogService, CalcUnStableRatioPostureLogService calcUnStableRatioPostureLogService) {
+        this.findPostureLogService = findPostureLogService;
+        this.calcUnStableRatioPostureLogService = calcUnStableRatioPostureLogService;
+    }
+
+    public UnStableRatioDTO getUnStableRatio(Long memberId) {
+        List<FindPostureLogDTO> weeklyPostureLogList = findPostureLogService.findWeeklyByMemberId(memberId);
+        return calcUnStableRatioPostureLogService.calculate(weeklyPostureLogList);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/PostureTimePerDate.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/PostureTimePerDate.java
@@ -1,7 +1,0 @@
-package com.spinetracker.spinetracker.domain.posture.query.domain;
-
-public class PostureTimePerDate {
-    private int focusTime;
-    private int TextNeckTime;
-    private int AsymmetryTime;
-}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/service/CalcUnStableRatioPostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/query/domain/service/CalcUnStableRatioPostureLogService.java
@@ -1,0 +1,48 @@
+package com.spinetracker.spinetracker.domain.posture.query.domain.service;
+
+import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.enumtype.PostureTag;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.FindPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.UnStableRatioDTO;
+import com.spinetracker.spinetracker.global.common.annotation.DomainService;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@DomainService
+public class CalcUnStableRatioPostureLogService {
+
+    public UnStableRatioDTO calculate(List<FindPostureLogDTO> findPostureLogDTOList) {
+        Map<String, Double> unStableTotalTimeMap = new HashMap<>();
+        Double unStableTotalTime = 0.0;
+        for(PostureTag tag : PostureTag.values()) {
+            if (!tag.name().equals("START") && !tag.name().equals("END")) {
+                unStableTotalTimeMap.putIfAbsent(tag.name(), 0.0);
+            }
+        }
+
+        if(!findPostureLogDTOList.isEmpty()) {
+            for(FindPostureLogDTO findPostureLogDTO: findPostureLogDTOList) {
+                if(!findPostureLogDTO.getPostureTag().equals("START") && !findPostureLogDTO.getPostureTag().equals("END")) {
+                    Duration duration = Duration.between(findPostureLogDTO.getStartTime(), findPostureLogDTO.getEndTime());
+                    int diffSec = (int) duration.getSeconds();
+                    unStableTotalTime = unStableTotalTime + diffSec;
+                    unStableTotalTimeMap.put(findPostureLogDTO.getPostureTag(), unStableTotalTimeMap.get(findPostureLogDTO.getPostureTag()) + diffSec);
+                }
+            }
+
+            return new UnStableRatioDTO(
+                    roundRatio(unStableTotalTimeMap.get("TEXTNECK") / unStableTotalTime),
+                    roundRatio(unStableTotalTimeMap.get("ASYMMETRY") / unStableTotalTime),
+                    roundRatio(unStableTotalTimeMap.get("STOOPED") / unStableTotalTime),
+                    roundRatio(unStableTotalTimeMap.get("SLEEPINESS") / unStableTotalTime)
+            );
+        }
+        return null;
+    }
+
+    private Double roundRatio(Double ratio) {
+        return (double) Math.round(ratio*100) / 100;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
@@ -93,7 +93,7 @@ public class SecurityConfiguration {
                                         "/swagger-ui/**", "/swagger","/webjars/**"
                                 )
                                 .antMatchers(
-                                        "/login/**"
+                                        "/login/**", "/posture/ratio"
                                 )
                 )
                 .authorizeHttpRequests((authorize) -> authorize.anyRequest().permitAll());


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #67 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `memberId`를 UserPrinciple에서 가져오지 않고 query paramter를 통해 값을 받도록 하였습니다.
* `/posture/ratio` API의 경우 JWT 토큰을 사용하지 않으므로, JWT 토큰을 검증하는 Filter를 거치지 않도록 하였습니다.
---

# 관련 스크린샷

<img width="1425" alt="CleanShot 2023-09-21 at 12 57 30@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/53e27f87-8f99-4274-bbe6-744347a67628">

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 없음
