### PR TITLE
[Closes #77] FEAT : 사용자 추가 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/FindMemberInfoDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/FindMemberInfoDTO.java
@@ -47,10 +47,6 @@ public class FindMemberInfoDTO {
         return this;
     }
 
-    public FindMemberInfoDTO setAgeRange(LocalDate birthdate) {
-        this.birthdate = birthdate;
-        return this;
-    }
 
     public FindMemberInfoDTO setJob(String job) {
         this.job = job;

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
@@ -1,6 +1,7 @@
 package com.spinetracker.spinetracker.domain.member.query.application.controller;
 
 import com.spinetracker.spinetracker.domain.member.command.application.dto.CheckMemberInfoAddedDTO;
+import com.spinetracker.spinetracker.domain.member.command.application.dto.FindMemberInfoDTO;
 import com.spinetracker.spinetracker.domain.member.query.application.dto.FindMemberDTO;
 import com.spinetracker.spinetracker.domain.member.query.application.service.FindMemberService;
 import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "MemberInfo", description = "유저 정보 관련 API")
@@ -29,7 +31,6 @@ public class FindMemberInfoController {
         this.findMemberService = findMemberService;
     }
 
-    // 회원가입 시 추가 정보 입력 여부 확인 조회
     @Operation(
             summary = "추가 정보 입력 여부 확인",
             description = "로그인 시 추가 정보가 입력이 되어있는 회원인지 확인합니다."
@@ -49,7 +50,6 @@ public class FindMemberInfoController {
                 );
     }
 
-    // 현재 로그인 되어 있는 유저 정보를 가져오는 API
     @Operation(
             summary = "유저 정보 조회",
             description = "현재 로그인 되어 있는 회원의 정보를 확인합니다."
@@ -71,5 +71,24 @@ public class FindMemberInfoController {
                         findMember.getName(),
                         findMember.getProfileImage(),
                         findMember.getRole()));
+    }
+
+    @Operation(
+            summary = "유저 추가 정보 조회",
+            description = "회원의 추가 정보를 확인합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FindMemberInfoDTO.class))}),
+    })
+    @GetMapping("/info/detail")
+    public ResponseEntity<FindMemberInfoDTO> getMemberInfo(@RequestParam Long memberId) {
+
+        System.out.println("memberId = " + memberId);
+        FindMemberInfoDTO findMemberInfo = findMemberService.findInfoById(memberId);
+        System.out.println("findMemberInfo = " + findMemberInfo);
+
+        return ResponseEntity.ok()
+                .body(findMemberInfo);
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
@@ -81,7 +81,7 @@ public class FindMemberInfoController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FindMemberInfoDTO.class))}),
     })
-    @GetMapping("/info/detail")
+    @GetMapping("/info")
     public ResponseEntity<FindMemberInfoDTO> getMemberInfo(@RequestParam Long memberId) {
 
         FindMemberInfoDTO findMemberInfo = findMemberService.findInfoById(memberId);

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
@@ -84,9 +84,7 @@ public class FindMemberInfoController {
     @GetMapping("/info/detail")
     public ResponseEntity<FindMemberInfoDTO> getMemberInfo(@RequestParam Long memberId) {
 
-        System.out.println("memberId = " + memberId);
         FindMemberInfoDTO findMemberInfo = findMemberService.findInfoById(memberId);
-        System.out.println("findMemberInfo = " + findMemberInfo);
 
         return ResponseEntity.ok()
                 .body(findMemberInfo);

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/service/FindMemberService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/service/FindMemberService.java
@@ -1,5 +1,6 @@
 package com.spinetracker.spinetracker.domain.member.query.application.service;
 
+import com.spinetracker.spinetracker.domain.member.command.application.dto.FindMemberInfoDTO;
 import com.spinetracker.spinetracker.domain.member.query.application.dto.FindMemberDTO;
 import com.spinetracker.spinetracker.domain.member.query.domain.repository.MemberInfoMapper;
 import com.spinetracker.spinetracker.domain.member.query.domain.repository.MemberMapper;
@@ -46,6 +47,7 @@ public class FindMemberService {
         return memberMapper.findById(memberId);
     }
 
+
     public FindMemberDTO findByEmail(String email) {
 
         FindMemberDTO findMember = memberMapper.findByEmail(email);
@@ -55,6 +57,12 @@ public class FindMemberService {
     }
 
     public Boolean isAddedInformation(Long id) {
+
         return !memberInfoMapper.isAddedInformation(id);
+    }
+
+    public FindMemberInfoDTO findInfoById(Long memberId) throws UserNotFoundException {
+
+        return memberInfoMapper.findInfoById(memberId);
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/query/domain/repository/MemberInfoMapper.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/query/domain/repository/MemberInfoMapper.java
@@ -1,9 +1,12 @@
 package com.spinetracker.spinetracker.domain.member.query.domain.repository;
 
+import com.spinetracker.spinetracker.domain.member.command.application.dto.FindMemberInfoDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface MemberInfoMapper {
 
     Boolean isAddedInformation(Long id);
+
+    FindMemberInfoDTO findInfoById(Long memberId);
 }

--- a/src/main/resources/mapper/member/MemberInfoMapper.xml
+++ b/src/main/resources/mapper/member/MemberInfoMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="com.spinetracker.spinetracker.domain.member.query.domain.repository.MemberInfoMapper">
     <resultMap id="MemberInfoMap" type="com.spinetracker.spinetracker.domain.member.command.application.dto.FindMemberInfoDTO">
-        <id property="id" column="id/"/>
+        <id property="id" column="id"/>
         <result property="gender" column="gender"/>
         <result property="birthdate" column="birth_date"/>
         <result property="job" column="job"/>
@@ -18,5 +18,17 @@
                 MEMBERINFO_TB
           WHERE
                 member_id = #{id}
+    </select>
+
+    <select id="findInfoById" resultMap="MemberInfoMap">
+        SELECT
+              id
+            , gender
+            , birth_date
+            , job
+          FROM
+              MEMBERINFO_TB
+         WHERE
+             member_id = #{memberId}
     </select>
 </mapper>


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #77 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 회원의 추가 정보를 조회할 수 있는 API를 query param으로 구현하였고, swagger 설정을 하였습니다.
---

# 관련 스크린샷

---
<img width="542" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/2b2f3abf-0f9a-4c56-b232-20b84227380b">

---

# 테스트 계획 또는 완료 사항

---
* 없음
