### PR TITLE
[Closes #82] FEAT : BOARD DELETE APPLICATION SERVICE 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardService.java
@@ -1,0 +1,32 @@
+package com.spinetracker.spinetracker.domain.board.command.application.service;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.BoardDTO;
+import com.spinetracker.spinetracker.domain.board.command.domain.aggregate.entity.Board;
+import com.spinetracker.spinetracker.domain.board.command.domain.repository.BoardRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class DeleteBoardService {
+    private final BoardRepository boardRepository;
+
+    @Autowired
+    public DeleteBoardService(BoardRepository boardRepository) {
+        this.boardRepository = boardRepository;
+    }
+
+    @Transactional
+    public Board deletePost(Long boardId, Long memberId, BoardDTO boardDTO) {
+        Optional<Board> findBoard = boardRepository.findBoardByIdAndWriter_Id(boardId, memberId);
+        if(findBoard.isPresent()) {
+            Board board = findBoard.get();
+            board.setBoardIsDeleted(true);
+
+            return board;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardService.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 public class UpdateBoardService {
 
@@ -18,7 +20,15 @@ public class UpdateBoardService {
     }
 
     @Transactional
-    public Board updatePost(BoardDTO boardDTO) {
- return null;
+    public Board updatePost(Long boardId, Long memberId, BoardDTO boardDTO) {
+        Optional<Board> findBoard = boardRepository.findBoardByIdAndWriter_Id(boardId, memberId);
+        if(findBoard.isPresent()) {
+            Board board = findBoard.get();
+            board.setTitle(boardDTO.getTitle());
+            board.setContent(boardDTO.getContent());
+
+            return board;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/repository/BoardRepository.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/repository/BoardRepository.java
@@ -4,6 +4,9 @@ import com.spinetracker.spinetracker.domain.board.command.domain.aggregate.entit
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
+    Optional<Board> findBoardByIdAndWriter_Id(Long id, Long memberId);
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Member", description = "유저 탈퇴 관련 API")
+@Tag(name = "Member", description = "유저 관련 API")
 @RestController
 @RequestMapping("/member")
 public class MemberController {

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardServiceTest.java
@@ -1,0 +1,46 @@
+package com.spinetracker.spinetracker.domain.board.command.application.service;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.BoardDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+@SpringBootTest
+@Transactional
+class DeleteBoardServiceTest {
+
+    @Autowired
+    private DeleteBoardService deleteBoardService;
+
+    public static Stream<Arguments> getDeleteBoardInfo() {
+        return Stream.of(
+                Arguments.of(
+                        1L,
+                        2L,
+                        new BoardDTO(
+                                "게시물제목",
+                                "게시물내용",
+                                "상품번호",
+                                "상품URL"
+                        )
+                )
+        );
+    }
+
+    @DisplayName("BoardDTO 통해 게시물 삭제가 되는지 확인")
+    @ParameterizedTest
+    @MethodSource("getDeleteBoardInfo")
+    void deletePost(Long boardId, Long memberId, BoardDTO boardDTO) {
+
+        Assertions.assertDoesNotThrow(
+                () -> deleteBoardService.deletePost(boardId, memberId, boardDTO)
+        );
+    }
+}

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardServiceTest.java
@@ -1,0 +1,47 @@
+package com.spinetracker.spinetracker.domain.board.command.application.service;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.BoardDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+@SpringBootTest
+@Transactional
+class UpdateBoardServiceTest {
+
+    @Autowired
+    private UpdateBoardService updateBoardService;
+
+    private static Stream<Arguments> getUpdateBoardInfo() {
+        return Stream.of(
+                Arguments.of(
+                        1L,
+                        2L,
+                        new BoardDTO(
+                                "게시판제목",
+                                "게시판내용",
+                                "상품아이디",
+                                "상품주소"
+
+                        )
+                )
+        );
+    }
+
+    @DisplayName("BoardDTO 통해 게시물 수정이 되는지 확인")
+    @ParameterizedTest
+    @MethodSource("getUpdateBoardInfo")
+    void updatePost(Long boardId, Long memberId, BoardDTO boardDTO) {
+
+        Assertions.assertDoesNotThrow(
+                () -> updateBoardService.updatePost(boardId, memberId, boardDTO)
+        );
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #82 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 게시글이 생성되면 BoardDTO 부분에 boardIsDeleted = false로 구현해 놓았는데, 게시글이 삭제가 되면 true로 바뀌게 구현하였습니다.
---

# 관련 스크린샷

---
<img width="698" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/1b4f550b-b51f-4831-ae0d-cf1fb4db0ff2">

---

# 테스트 계획 또는 완료 사항

---
* BoardDTO 통해 게시물 삭제가 되는지 확인 테스트 완료하였습니다.
