### PR TITLE
[Closes #84] FEAT : BOARD READ APPLICATION SERVICE 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/FindBoardDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/FindBoardDTO.java
@@ -1,0 +1,36 @@
+package com.spinetracker.spinetracker.domain.board.command.application.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class FindBoardDTO {
+    private String title;
+    private String content;
+    private String productId;
+    private String productUrl;
+
+    public FindBoardDTO(String title, String content, String productId, String productUrl) {
+        this.title = title;
+        this.content = content;
+        this.productId = productId;
+        this.productUrl = productUrl;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public void setProductUrl(String productUrl) {
+        this.productUrl = productUrl;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
@@ -1,0 +1,24 @@
+package com.spinetracker.spinetracker.domain.board.query.application.service;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.FindBoardDTO;
+import com.spinetracker.spinetracker.domain.board.query.domain.repository.BoardMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FindBoardService {
+
+    private final BoardMapper boardMapper;
+
+    @Autowired
+    public FindBoardService(BoardMapper boardMapper) {
+        this.boardMapper = boardMapper;
+    }
+
+    public List<FindBoardDTO> findAllPost() {
+
+        return boardMapper.findAllPost();
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/domain/repository/BoardMapper.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/domain/repository/BoardMapper.java
@@ -1,0 +1,11 @@
+package com.spinetracker.spinetracker.domain.board.query.domain.repository;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.FindBoardDTO;
+import org.apache.ibatis.annotations.Mapper;
+import java.util.List;
+
+@Mapper
+public interface BoardMapper {
+
+    List<FindBoardDTO> findAllPost();
+}

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
@@ -93,7 +93,7 @@ public class SecurityConfiguration {
                                         "/swagger-ui/**", "/swagger","/webjars/**"
                                 )
                                 .antMatchers(
-                                        "/login/**", "/posture/ratio"
+                                        "/login/**", "/posture/ratio", "/member/info"
                                 )
                 )
                 .authorizeHttpRequests((authorize) -> authorize.anyRequest().permitAll());

--- a/src/main/resources/mapper/board/BoardMapper.xml
+++ b/src/main/resources/mapper/board/BoardMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.spinetracker.spinetracker.domain.board.query.domain.repository.BoardMapper">
+    <resultMap id="BoardMap" type="com.spinetracker.spinetracker.domain.board.command.application.dto.FindBoardDTO">
+        <id property="id" column="id"/>
+        <result property="title" column="title"/>
+        <result property="content" column="content"/>
+        <result property="productId" column="product_id"/>
+        <result property="productUrl" column="product_url"/>
+    </resultMap>
+
+    <select id="findAllPost" resultMap="BoardMap" parameterType="Map">
+        SELECT
+                title
+              , content
+              , product_id
+              , product_url
+          FROM
+                BOARD_TB
+          WHERE
+                board_is_deleted = false
+    </select>
+</mapper>

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
@@ -1,0 +1,46 @@
+package com.spinetracker.spinetracker.domain.board.query.application.service;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.FindBoardDTO;
+import com.spinetracker.spinetracker.domain.board.query.domain.repository.BoardMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class FindBoardServiceTest {
+
+    @Autowired
+    private FindBoardService findBoardService;
+    private static Stream<Arguments> getBoardInfo() {
+        return Stream.of(
+                Arguments.of(
+                        new FindBoardDTO(
+                                "게시물제목",
+                                "게시물내용",
+                                "상품번호",
+                                "상품url"
+                        )
+                )
+        );
+    }
+
+    @DisplayName("FindBoardDTO를 통해 게시물이 조회되는지 확인")
+    @ParameterizedTest
+    @MethodSource("getBoardInfo")
+    @Transactional
+    void boardInfo() {
+
+        Assertions.assertDoesNotThrow(() -> findBoardService.findAllPost());
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #84 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* FindBoardDTO를 생성하여 게시판 전체 조회를 구현하였습니다. 추후 게시판 세부 조회 구현 예정입니다.
* PRODUCT를 엔티티로 기존 BOARD 엔티티와 따로 분리하여 refactoring 예정입니다.

# 관련 스크린샷

---
<img width="286" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/aa661d27-7db9-4574-82ba-b85559ca8779">

---

# 테스트 계획 또는 완료 사항

---
* FindBoardDTO를 통해 게시물이 조회되는지 확인 테스트 완료하였습니다.
