### PR TITLE
[Closes #90] Feat : BOARD 게시글 전체 조회 CONTROLLER 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/entity/Board.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/entity/Board.java
@@ -26,7 +26,7 @@ public class Board {
     @Embedded
     private ProductVO product;
 
-    @Column(name = "board_is_deleted")
+    @Column(name = "board_is_deleted", nullable = false)
     private boolean boardIsDeleted;
 
     @CreatedDate

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/controller/FindBoardController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/controller/FindBoardController.java
@@ -1,0 +1,45 @@
+package com.spinetracker.spinetracker.domain.board.query.application.controller;
+
+import com.spinetracker.spinetracker.domain.board.query.application.dto.FindBoardDTO;
+import com.spinetracker.spinetracker.domain.board.query.application.service.FindBoardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+@Tag(name = "Board", description = "게시판 관련 API")
+@RestController
+@RequestMapping("/board")
+public class FindBoardController {
+
+    private final FindBoardService findBoardService;
+
+    @Autowired
+    public FindBoardController(FindBoardService findBoardService) {
+        this.findBoardService = findBoardService;
+    }
+
+    @Operation(
+            summary = "게시판 글 전체 조회",
+            description = "게시판에 등록되어있는 글을 전체 조회 합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FindBoardDTO.class))}),
+    })
+    @GetMapping("/list")
+    public ResponseEntity<List<FindBoardDTO>> getBoardInfo() {
+
+        List<FindBoardDTO> findBoard = findBoardService.findAllPost();
+
+        return ResponseEntity.ok().body(findBoard);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindBoardDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindBoardDTO.java
@@ -21,6 +21,10 @@ public class FindBoardDTO {
     @JsonProperty("writer_name")
     private final String writerName;
 
+    @Schema(type = "String", example = "프로필 URL", description = "작성자 프로필 이미지 입니다.")
+    @JsonProperty("profile_image")
+    private final String profileImage;
+
     @Schema(type = "String", example = "게시글 내용", description = "게시글 본문 내용 입니다.")
     private final String content;
 
@@ -36,10 +40,11 @@ public class FindBoardDTO {
     @JsonProperty("image_url")
     private final String imageUrl;
 
-    public FindBoardDTO(Long boardId, Long writerId, String writerName, String content, String productName, String productUrl, String imageUrl) {
+    public FindBoardDTO(Long boardId, Long writerId, String writerName, String profileImage, String content, String productName, String productUrl, String imageUrl) {
         this.boardId = boardId;
         this.writerId = writerId;
         this.writerName = writerName;
+        this.profileImage = profileImage;
         this.content = content;
         this.productName = productName;
         this.productUrl = productUrl;

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindBoardDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindBoardDTO.java
@@ -1,19 +1,43 @@
 package com.spinetracker.spinetracker.domain.board.query.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
 public class FindBoardDTO {
+
+    @Schema(type = "Long", example = "1", description = "게시판 번호 입니다.")
+    @JsonProperty("board_id")
+    private final Long boardId;
+
+    @Schema(type = "Long", example = "1", description = "작성자 번호 입니다.")
+    @JsonProperty("writer_id")
     private final Long writerId;
+
+    @Schema(type = "String", example = "홍길동", description = "작성자 이름 입니다.")
+    @JsonProperty("writer_name")
     private final String writerName;
+
+    @Schema(type = "String", example = "게시글 내용", description = "게시글 본문 내용 입니다.")
     private final String content;
+
+    @Schema(type = "String", example = "상품 이름", description = "상품 이름 입니다.")
+    @JsonProperty("product_name")
     private final String productName;
+
+    @Schema(type = "String", example = "상품 URL", description = "상품 URL 입니다.")
+    @JsonProperty("product_url")
     private final String productUrl;
+
+    @Schema(type = "String", example = "이미지 URL", description = "이미지 URL 입니다.")
+    @JsonProperty("image_url")
     private final String imageUrl;
 
-    public FindBoardDTO(Long writerId, String writerName, String content, String productName, String productUrl, String imageUrl) {
+    public FindBoardDTO(Long boardId, Long writerId, String writerName, String content, String productName, String productUrl, String imageUrl) {
+        this.boardId = boardId;
         this.writerId = writerId;
         this.writerName = writerName;
         this.content = content;

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindPostDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindPostDTO.java
@@ -8,13 +8,15 @@ import lombok.ToString;
 @ToString
 @Setter
 public class FindPostDTO {
+    private Long id;        // 게시판 번호
     private Long writerId;
     private String content;
     private Long productId;
 
     public FindPostDTO() {}
 
-    public FindPostDTO(String writerId, String content, Long productId) {
+    public FindPostDTO(Long id, String writerId, String content, Long productId) {
+        this.id = id;
         this.writerId = getWriterId();
         this.content = content;
         this.productId = productId;

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindPostDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindPostDTO.java
@@ -15,7 +15,7 @@ public class FindPostDTO {
 
     public FindPostDTO() {}
 
-    public FindPostDTO(Long id, String writerId, String content, Long productId) {
+    public FindPostDTO(Long id, Long writerId, String content, Long productId) {
         this.id = id;
         this.writerId = getWriterId();
         this.content = content;

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
@@ -40,6 +40,7 @@ public class FindBoardService {
                       findPost.getId(),
                       findPost.getWriterId(),
                       findMember.getName(),
+                      findMember.getProfileImage(),
                       findPost.getContent(),
                       findProduct.getProductName(),
                       findProduct.getProductUrl(),

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
@@ -28,7 +28,7 @@ public class FindBoardService {
 
     public List<FindBoardDTO> findAllPost() {
 
-        List<FindPostDTO> findAllPostList =  boardMapper.findAllPost();
+        List<FindPostDTO> findAllPostList = boardMapper.findAllPost();
 
         List<FindBoardDTO> findBoardDTOList = new ArrayList<>();
 

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
@@ -37,6 +37,7 @@ public class FindBoardService {
             FindMemberDTO findMember = findMemberService.findById(findPost.getWriterId());
             findBoardDTOList.add(
               new FindBoardDTO(
+                      findPost.getId(),
                       findPost.getWriterId(),
                       findMember.getName(),
                       findPost.getContent(),

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/controller/MemberInfoController.java
@@ -48,7 +48,7 @@ public class MemberInfoController {
 
         Long memberId = userPrincipal.getId();
 
-        if (createMemberInfoDTO.getGender() == null || createMemberInfoDTO.getBirthdate() == null || createMemberInfoDTO.getJob() == null) {
+        if (createMemberInfoDTO.getGender().isEmpty() || createMemberInfoDTO.getBirthdate() == null || createMemberInfoDTO.getJob() == null) {
             throw new RuntimeException("정보를 모두 입력해야 합니다.");
         }
 

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/query/application/controller/FindMemberInfoController.java
@@ -81,7 +81,7 @@ public class FindMemberInfoController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = FindMemberInfoDTO.class))}),
     })
-    @GetMapping("/info")
+    @GetMapping("/info/query")
     public ResponseEntity<FindMemberInfoDTO> getMemberInfo(@RequestParam Long memberId) {
 
         FindMemberInfoDTO findMemberInfo = findMemberService.findInfoById(memberId);

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
@@ -93,7 +93,7 @@ public class SecurityConfiguration {
                                         "/swagger-ui/**", "/swagger","/webjars/**"
                                 )
                                 .antMatchers(
-                                        "/login/**", "/posture/ratio", "/member/info"
+                                        "/login/**", "/posture/ratio", "/member/info/query"
                                 )
                 )
                 .authorizeHttpRequests((authorize) -> authorize.anyRequest().permitAll());
@@ -120,7 +120,7 @@ public class SecurityConfiguration {
                 .authorizeRequests()
                     .antMatchers("/oauth2/**", "/auth/**")
                         .hasRole(RoleEnum.MEMBER.name())
-                .antMatchers("/blog/**", "/member/**")
+                .antMatchers("/blog/**", "/member/**", "/board/**")
                     .permitAll()
                 .antMatchers("/admin/**")
                     .hasRole(RoleEnum.ADMIN.name())

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.stream.Stream;
 
 @SpringBootTest
-@Transactional
 class CreateBoardServiceTest {
 
     @Autowired

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
@@ -37,6 +37,7 @@ class CreateBoardServiceTest {
     @DisplayName("boardDTO를 통해 게시글이 생성 되는지 확인")
     @ParameterizedTest
     @MethodSource("getCreatePost")
+    @Transactional
     void createPost(Long memberId, CreatePostDTO boardDTO) {
 
         Assertions.assertDoesNotThrow(

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
@@ -1,7 +1,6 @@
 package com.spinetracker.spinetracker.domain.board.query.application.service;
 
 import com.spinetracker.spinetracker.domain.board.query.application.dto.FindBoardDTO;
-import com.spinetracker.spinetracker.domain.board.query.application.dto.FindPostDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,6 +21,7 @@ class FindBoardServiceTest {
         return Stream.of(
                 Arguments.of(
                         new FindBoardDTO(
+                                1L,
                                 1L,
                                 "게시물제목",
                                 "게시물내용",

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
@@ -1,13 +1,18 @@
 package com.spinetracker.spinetracker.domain.board.query.application.service;
 
-import com.spinetracker.spinetracker.domain.board.query.application.dto.FindBoardDTO;
+import com.spinetracker.spinetracker.domain.board.command.application.service.CreateBoardService;
+import com.spinetracker.spinetracker.domain.board.query.application.dto.FindPostDTO;
+import com.spinetracker.spinetracker.domain.board.query.domain.repository.BoardMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Stream;
@@ -17,18 +22,19 @@ class FindBoardServiceTest {
 
     @Autowired
     private FindBoardService findBoardService;
+    @Autowired
+    private CreateBoardService createBoardService;
+
+    @MockBean
+    private BoardMapper boardMapper;
     private static Stream<Arguments> getBoardInfo() {
         return Stream.of(
                 Arguments.of(
-                        new FindBoardDTO(
+                        new FindPostDTO(
                                 1L,
                                 1L,
-                                "게시물제목",
-                                "profileImage",
                                 "게시물내용",
-                                "효정",
-                                "ADASDASD",
-                                "ASDASDSAD"
+                                    1L
                         )
                 )
         );
@@ -38,7 +44,12 @@ class FindBoardServiceTest {
     @ParameterizedTest
     @MethodSource("getBoardInfo")
     @Transactional
-    void boardInfo() {
+    void boardInfo(FindPostDTO findPostDTO) {
+
+//        List<FindPostDTO> findAllPostList = new ArrayList<>();
+//
+//        findAllPostList.add(findPostDTO);
+//        when(boardMapper.findAllPost()).thenReturn(findAllPostList);
 
         Assertions.assertDoesNotThrow(() -> findBoardService.findAllPost());
     }

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
@@ -22,11 +22,7 @@ class FindBoardServiceTest {
 
     @Autowired
     private FindBoardService findBoardService;
-    @Autowired
-    private CreateBoardService createBoardService;
 
-    @MockBean
-    private BoardMapper boardMapper;
     private static Stream<Arguments> getBoardInfo() {
         return Stream.of(
                 Arguments.of(

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
@@ -24,6 +24,7 @@ class FindBoardServiceTest {
                                 1L,
                                 1L,
                                 "게시물제목",
+                                "profileImage",
                                 "게시물내용",
                                 "효정",
                                 "ADASDASD",

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardServiceTest.java
@@ -1,18 +1,13 @@
 package com.spinetracker.spinetracker.domain.board.query.application.service;
 
-import com.spinetracker.spinetracker.domain.board.command.application.service.CreateBoardService;
 import com.spinetracker.spinetracker.domain.board.query.application.dto.FindPostDTO;
-import com.spinetracker.spinetracker.domain.board.query.domain.repository.BoardMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
-import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Stream;


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #90 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 게시판에 있는 글을 전체 조회하기 위해 List<FindBoardDTO>를 이용하여 body에 값을 담았습니다.
* 기존에 있던 post /info가 url 매핑이 중복되어 FindMemberInfoController에 queryparam으로 넘겨서 url을 /info/query로 수정하였습니다.
---

# 관련 스크린샷

---
<img width="360" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/7cfd971a-48fd-47f5-b23b-f2761e8b1b65">

---

# 테스트 계획 또는 완료 사항

---
* 없음
