### PR TITLE
[Closes #94] Feat : BOARD 게시글 생성 CONTROLLER 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/BoardController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/BoardController.java
@@ -1,0 +1,56 @@
+package com.spinetracker.spinetracker.domain.board.command.application.controller;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.CreatePostDTO;
+import com.spinetracker.spinetracker.domain.board.command.application.dto.CreatedBoardResponseDTO;
+import com.spinetracker.spinetracker.domain.board.command.application.service.CreateBoardService;
+import com.spinetracker.spinetracker.domain.board.command.domain.aggregate.entity.Board;
+import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@Tag(name = "Board", description = "게시판 관련 API")
+@RestController
+@RequestMapping("/board")
+public class BoardController {
+
+    private final CreateBoardService createBoardService;
+
+    @Autowired
+    public BoardController(CreateBoardService createBoardService) {
+        this.createBoardService = createBoardService;
+    }
+
+    @Operation(
+            summary = "게시판 글 작성",
+            description = "게시판에 글을 등록합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CreatePostDTO.class))}),
+    })
+    @PostMapping
+    public ResponseEntity<CreatedBoardResponseDTO> createPost(@CurrentMember UserPrincipal userPrincipal, @RequestBody CreatePostDTO createPostDTO) {
+
+        Long memberId = userPrincipal.getId();
+
+        Board createdBoard = createBoardService.createPost(memberId, createPostDTO);
+
+        return ResponseEntity.created(URI.create("/board"))
+                .body(new CreatedBoardResponseDTO(
+                        createdBoard.getId()
+                ));
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/CreatePostDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/CreatePostDTO.java
@@ -1,17 +1,37 @@
 package com.spinetracker.spinetracker.domain.board.command.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
 public class CreatePostDTO {
-    private final Long writer;         // 글 작성자
-    private final String productName;  // 상품 이름(글 제목)
-    private final String content;      // 상품 내용
-    private final Long productId;      // 상품id
-    private final String productUrl;   // 상품url
-    private final String imageUrl;     // 상품이미지url
+
+    @Schema(type = "Long", example = "1", description = "글 작성자 번호 입니다.")
+    private Long writer;
+
+    @Schema(type = "String", example = "상품 이름", description = "상품 이름 입니다.")
+    @JsonProperty("product_name")
+    private String productName;
+
+    @Schema(type = "String", example = "게시글 내용", description = "게시글 본문 내용 입니다.")
+    private String content;
+
+    @Schema(type = "Long", example = "1", description = "상품 번호 입니다.")
+    @JsonProperty("product_id")
+    private Long productId;
+
+    @Schema(type = "String", example = "상품 URL", description = "상품 URL 입니다.")
+    @JsonProperty("product_url")
+    private String productUrl;
+
+    @Schema(type = "String", example = "이미지 URL", description = "이미지 URL 입니다.")
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    public CreatePostDTO() {}
 
     public CreatePostDTO(Long writer, String productName, String content, Long productId, String productUrl, String imageUrl) {
         this.writer = writer;

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/CreatedBoardResponseDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/CreatedBoardResponseDTO.java
@@ -1,0 +1,15 @@
+package com.spinetracker.spinetracker.domain.board.command.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class CreatedBoardResponseDTO {
+
+    @Schema(type = "Long", example = "1", description = "새로 생성된 게시판의 번호입니다.")
+    @JsonProperty("board_id")
+    private final Long boardId;
+
+    public CreatedBoardResponseDTO(Long boardId) {
+        this.boardId = boardId;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/controller/FindBoardController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/controller/FindBoardController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-@Tag(name = "Board", description = "게시판 관련 API")
+@Tag(name = "Board", description = "게시판 조회 관련 API")
 @RestController
 @RequestMapping("/board")
 public class FindBoardController {


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #94 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음 
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* CreatedBoardResponseDTO를 생성하여 새로 생성된 게시판의 번호가 return 되도록 구현하였습니다.
* swagger 설정 완료하였습니다.
---

# 관련 스크린샷

---
<img width="451" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/f255739d-e763-4076-adfd-5825732f0b8f">
<img width="580" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/f1415ef6-44c8-4c14-83fd-48554dce6095">


---

# 테스트 계획 또는 완료 사항

---
* board 관련 controller 테스트 예정입니다.
