### PR TITLE
[Closes #101] Feat : BOARD 게시글 삭제 CONTROLLER 구현

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/BoardController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/BoardController.java
@@ -4,6 +4,7 @@ import com.spinetracker.spinetracker.domain.board.command.application.dto.Create
 import com.spinetracker.spinetracker.domain.board.command.application.dto.CreatedBoardResponseDTO;
 import com.spinetracker.spinetracker.domain.board.command.application.dto.UpdatePostDTO;
 import com.spinetracker.spinetracker.domain.board.command.application.service.CreateBoardService;
+import com.spinetracker.spinetracker.domain.board.command.application.service.DeleteBoardService;
 import com.spinetracker.spinetracker.domain.board.command.application.service.UpdateBoardService;
 import com.spinetracker.spinetracker.domain.board.command.domain.aggregate.entity.Board;
 import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
@@ -27,11 +28,13 @@ public class BoardController {
 
     private final CreateBoardService createBoardService;
     private final UpdateBoardService updateBoardService;
+    private final DeleteBoardService deleteBoardService;
 
     @Autowired
-    public BoardController(CreateBoardService createBoardService, UpdateBoardService updateBoardService) {
+    public BoardController(CreateBoardService createBoardService, UpdateBoardService updateBoardService, DeleteBoardService deleteBoardService) {
         this.createBoardService = createBoardService;
         this.updateBoardService = updateBoardService;
+        this.deleteBoardService = deleteBoardService;
     }
 
     @Operation(
@@ -40,7 +43,7 @@ public class BoardController {
     )
     // response 정보
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "Created", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = CreatePostDTO.class))}),
+            @ApiResponse(responseCode = "201", description = "Created", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = CreatePostDTO.class))}),
     })
     @PostMapping
     public ResponseEntity<CreatedBoardResponseDTO> createPost(@CurrentMember UserPrincipal userPrincipal, @RequestBody CreatePostDTO createPostDTO) {
@@ -61,7 +64,7 @@ public class BoardController {
     )
     // response 정보
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UpdatePostDTO.class))}),
+            @ApiResponse(responseCode = "200", description = "OK", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = UpdatePostDTO.class))}),
     })
     @PutMapping("/{boardId}")
     public ResponseEntity<UpdatePostDTO> updatePost(@CurrentMember UserPrincipal userPrincipal, @PathVariable Long boardId, @RequestBody UpdatePostDTO updatePostDTO) {
@@ -73,5 +76,24 @@ public class BoardController {
         return ResponseEntity.ok().body(new UpdatePostDTO(
                 updatedBoard.getContent(),
                 updatedBoard.getCreatedDate()));
+    }
+
+    @Operation(
+            summary = "게시판 글 삭제",
+            description = "게시판의 글을 삭제 합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "noContent"),
+    })
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<?> deletePost(@CurrentMember UserPrincipal userPrincipal, @PathVariable Long boardId) {
+
+        Long memberId = userPrincipal.getId();
+
+        deleteBoardService.deletePost(boardId, memberId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/BoardController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/BoardController.java
@@ -2,7 +2,9 @@ package com.spinetracker.spinetracker.domain.board.command.application.controlle
 
 import com.spinetracker.spinetracker.domain.board.command.application.dto.CreatePostDTO;
 import com.spinetracker.spinetracker.domain.board.command.application.dto.CreatedBoardResponseDTO;
+import com.spinetracker.spinetracker.domain.board.command.application.dto.UpdatePostDTO;
 import com.spinetracker.spinetracker.domain.board.command.application.service.CreateBoardService;
+import com.spinetracker.spinetracker.domain.board.command.application.service.UpdateBoardService;
 import com.spinetracker.spinetracker.domain.board.command.domain.aggregate.entity.Board;
 import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
 import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
@@ -14,10 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -27,15 +26,17 @@ import java.net.URI;
 public class BoardController {
 
     private final CreateBoardService createBoardService;
+    private final UpdateBoardService updateBoardService;
 
     @Autowired
-    public BoardController(CreateBoardService createBoardService) {
+    public BoardController(CreateBoardService createBoardService, UpdateBoardService updateBoardService) {
         this.createBoardService = createBoardService;
+        this.updateBoardService = updateBoardService;
     }
 
     @Operation(
             summary = "게시판 글 작성",
-            description = "게시판에 글을 등록합니다."
+            description = "게시판에 글을 등록 합니다."
     )
     // response 정보
     @ApiResponses(value = {
@@ -52,5 +53,25 @@ public class BoardController {
                 .body(new CreatedBoardResponseDTO(
                         createdBoard.getId()
                 ));
+    }
+
+    @Operation(
+            summary = "게시판 글 수정",
+            description = "게시판의 글을 수정 합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = UpdatePostDTO.class))}),
+    })
+    @PutMapping("/{boardId}")
+    public ResponseEntity<UpdatePostDTO> updatePost(@CurrentMember UserPrincipal userPrincipal, @PathVariable Long boardId, @RequestBody UpdatePostDTO updatePostDTO) {
+
+        Long memberId = userPrincipal.getId();
+
+        Board updatedBoard = updateBoardService.updatePost(memberId, boardId, updatePostDTO);
+
+        return ResponseEntity.ok().body(new UpdatePostDTO(
+                updatedBoard.getContent(),
+                updatedBoard.getCreatedDate()));
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/UpdatePostDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/UpdatePostDTO.java
@@ -1,14 +1,31 @@
 package com.spinetracker.spinetracker.domain.board.command.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
 @ToString
+@Setter
 public class UpdatePostDTO {
-    private final String content;
 
-    public UpdatePostDTO(String content) {
+    @Schema(type = "String", example = "게시글 내용", description = "게시글 본문 내용 입니다.")
+    private String content;
+
+    @Schema(type = "LocalDateTime", example = "2023-09-24 15:33:13", description = "게시판 수정 날짜 및 시간 입니다.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    @JsonProperty("created_date")
+    private LocalDateTime createdDate;
+
+    public UpdatePostDTO() {}
+
+    public UpdatePostDTO(String content, LocalDateTime createdDate) {
         this.content = content;
+        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardService.java
@@ -24,6 +24,7 @@ public class DeleteBoardService {
             Board board = findBoard.get();
             board.setBoardIsDeleted(true);
 
+            boardRepository.delete(board);
             return board;
         }
         return null;

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardService.java
@@ -20,12 +20,14 @@ public class UpdateBoardService {
     }
 
     @Transactional
-    public Board updatePost(Long boardId, Long memberId, UpdatePostDTO updatePostDTO) {
+    public Board updatePost(Long memberId, Long boardId, UpdatePostDTO updatePostDTO) {
+
         Optional<Board> findBoard = boardRepository.findBoardByIdAndWriter_Id(boardId, memberId);
         if(findBoard.isPresent()) {
             Board board = findBoard.get();
             board.setContent(updatePostDTO.getContent());
 
+            boardRepository.save(board);
             return board;
         }
         return null;

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
@@ -8,6 +8,7 @@ import com.spinetracker.spinetracker.domain.member.query.application.dto.FindMem
 import com.spinetracker.spinetracker.domain.member.query.application.service.FindMemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +27,7 @@ public class FindBoardService {
         this.findMemberService = findMemberService;
     }
 
+    @Transactional
     public List<FindBoardDTO> findAllPost() {
 
         List<FindPostDTO> findAllPostList = boardMapper.findAllPost();
@@ -33,7 +35,7 @@ public class FindBoardService {
         List<FindBoardDTO> findBoardDTOList = new ArrayList<>();
 
         for (FindPostDTO findPost : findAllPostList) {
-            FindProductDTO findProduct = findProductService.findByProductId(findPost.getProductId());
+            FindProductDTO findProduct = findProductService.findById(findPost.getProductId());
             FindMemberDTO findMember = findMemberService.findById(findPost.getWriterId());
             findBoardDTOList.add(
               new FindBoardDTO(

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindProductService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindProductService.java
@@ -15,8 +15,8 @@ public class FindProductService {
         this.productMapper = productMapper;
     }
 
-    public FindProductDTO findByProductId(Long id) {
+    public FindProductDTO findById(Long id) {
 
-        return productMapper.findByProductId(id);
+        return productMapper.findById(id);
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/domain/repository/ProductMapper.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/domain/repository/ProductMapper.java
@@ -6,5 +6,5 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface ProductMapper {
 
-    FindProductDTO findByProductId(Long id);
+    FindProductDTO findById(Long id);
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CheckMemberInfoAddedDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CheckMemberInfoAddedDTO.java
@@ -3,7 +3,10 @@ package com.spinetracker.spinetracker.domain.member.command.application.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class CheckMemberInfoAddedDTO {
     @Schema(type = "boolean", example = "true", description = "사용자 정보 추가 여부 입니다.")
     @JsonProperty("is_added")

--- a/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreatedMemberInfoResponseDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/member/command/application/dto/CreatedMemberInfoResponseDTO.java
@@ -15,7 +15,7 @@ public class CreatedMemberInfoResponseDTO {
     @Schema(type = "String", example = "FEMALE", description = "사용자 성별 입니다.", allowableValues = {"FEMALE", "MALE", "ETC"})
     private String gender;
 
-    @Schema(type = "String", example = "2023-09-20", description = "사용자 생년월일 입니다.")
+    @Schema(type = "LocalDate", example = "2023-09-20", description = "사용자 생년월일 입니다.")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone="Asia/Seoul")
     @JsonProperty("birth_date")
     private LocalDate birthDate;

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/UpdateBoardServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 @SpringBootTest
@@ -25,7 +26,8 @@ class UpdateBoardServiceTest {
                         1L,
                         2L,
                         new UpdatePostDTO(
-                                "게시판내용"
+                                "게시판내용",
+                                LocalDateTime.now()
                         )
                 )
         );


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #101 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음 
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* `@PathVariable` 어노테이션으로 boardId를 받아 게시물 삭제가 되게 구현하였습니다.
* swagger 설정 완료하였습니다.
---

# 관련 스크린샷

---
<img width="584" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/3c886a42-d5ba-4bf6-a9a5-54174f9f519c">

---

# 테스트 계획 또는 완료 사항

---
* board 관련 controller 테스트 예정입니다.
