### PR TITLE
[Closes #99] Feat :FCM 토큰FindController 구현

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -41,13 +41,12 @@ jobs:
           mysql user: ${{ secrets.MYSQL_USERNAME }}
           mysql password: ${{ secrets.MYSQL_PASSWORD }}
 
-      - name: make firebase-adminsdk-json
-        run:
-          touch ./src/main/resources/spinetracker-firebase-adminsdk.json
-        shell: bash
-      - name: deliver spinetracker-firebase-adminsdk.json
-        run: echo "${{ secrets.FIREBASE_ADMIN_SDK }}" | base64 -d > ./src/main/resources/spinetracker-firebase-adminsdk.json
-        shell: bash
+      - name: create-json
+        id: create-json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "spinetracker-firebase-adminsdk.json"
+          json: ${{ secrets.FIREBASE_ADMIN_SDK }}
 
       - name: make application.yml
         run:

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           name: "spinetracker-firebase-adminsdk.json"
           json: ${{ secrets.FIREBASE_ADMIN_SDK }}
+          dir: './src/main/resources/'
 
       - name: make application.yml
         run:

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -46,7 +46,7 @@ jobs:
           touch ./src/main/resources/spinetracker-firebase-adminsdk.json
         shell: bash
       - name: deliver spinetracker-firebase-adminsdk.json
-        run: echo "${{ secrets.FIREBASE_ADMIN_SDK }}" > ./src/main/resources/spinetracker-firebase-adminsdk.json
+        run: echo "${{ secrets.FIREBASE_ADMIN_SDK }}" | base64 -d > ./src/main/resources/spinetracker-firebase-adminsdk.json
         shell: bash
 
       - name: make application.yml

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/controller/CreatePostureController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/controller/CreatePostureController.java
@@ -4,14 +4,12 @@ import com.spinetracker.spinetracker.domain.posture.command.application.dto.Crea
 import com.spinetracker.spinetracker.domain.posture.command.application.dto.PostureBody;
 import com.spinetracker.spinetracker.domain.posture.command.application.dto.ResponsePosture;
 import com.spinetracker.spinetracker.domain.posture.command.application.service.CreatePostureLogService;
+import com.spinetracker.spinetracker.domain.posture.command.application.service.PostPostureLogMessageService;
 import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.entity.PostureLog;
 import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
 import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -31,10 +29,12 @@ import java.util.List;
 public class CreatePostureController {
 
     private final CreatePostureLogService createPostureLogService;
+    private final PostPostureLogMessageService postPostureLogMessageService;
 
     @Autowired
-    public CreatePostureController(CreatePostureLogService createPostureLogService) {
+    public CreatePostureController(CreatePostureLogService createPostureLogService, PostPostureLogMessageService postPostureLogMessageService) {
         this.createPostureLogService = createPostureLogService;
+        this.postPostureLogMessageService = postPostureLogMessageService;
     }
 
     // 메서드 정보
@@ -59,6 +59,7 @@ public class CreatePostureController {
             createdPostureLogList.add(createPostureLogService.create(memberId, createPostureLogDTO));
         }
 
+
         List<PostureBody> postureBodyList = getPostureBodies(createdPostureLogList);
         ResponsePosture responsePosture = new ResponsePosture(
                 ! postureBodyList.isEmpty(),
@@ -80,6 +81,10 @@ public class CreatePostureController {
                     postureLog.getDateTime().getEndTime()
             );
             postureBodyList.add(postureBody);
+
+            if(postureBody.getPostureTag().equals("END")) {
+                postPostureLogMessageService.postDailyPostureLogMessage(postureBody.getMemberId());
+            }
         }
         return postureBodyList;
     }

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/CreatePostureLogDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/dto/CreatePostureLogDTO.java
@@ -45,4 +45,14 @@ public class CreatePostureLogDTO {
         this.startTime = startTime;
         this.endTime = endTime;
     }
+
+    @Override
+    public String toString() {
+        return "CreatePostureLogDTO{" +
+                "postureTag='" + postureTag + '\'' +
+                ", date=" + date +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                '}';
+    }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/CreatePostureLogService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/CreatePostureLogService.java
@@ -9,6 +9,7 @@ import com.spinetracker.spinetracker.domain.posture.command.domain.aggregate.vo.
 import com.spinetracker.spinetracker.domain.posture.command.domain.repository.PostureLogRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,7 @@ public class CreatePostureLogService {
         this.postureLogRepository = postureLogRepository;
     }
 
+    @Transactional
     public PostureLog create(Long memberId, CreatePostureLogDTO createPostureLogDTO) {
 
         MemberVO member = new MemberVO(memberId);

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/PostPostureLogMessageService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/PostPostureLogMessageService.java
@@ -1,0 +1,32 @@
+package com.spinetracker.spinetracker.domain.posture.command.application.service;
+
+import com.spinetracker.spinetracker.domain.posture.command.domain.service.RequestPostFcmMessage;
+import com.spinetracker.spinetracker.domain.posture.query.application.dto.DailyPostureLogDTO;
+import com.spinetracker.spinetracker.domain.posture.query.application.service.FindDailyPostureLogService;
+import com.spinetracker.spinetracker.infra.firebase.query.application.dto.FindFcmTokenDTO;
+import com.spinetracker.spinetracker.infra.firebase.query.application.service.FindFcmTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PostPostureLogMessageService {
+
+    private final FindFcmTokenService findFcmTokenService;
+    private final RequestPostFcmMessage requestPostFcmMessage;
+    private final FindDailyPostureLogService findDailyPostureLogService;
+
+    @Autowired
+    public PostPostureLogMessageService(FindFcmTokenService findFcmTokenService, RequestPostFcmMessage requestPostFcmMessage, FindDailyPostureLogService findDailyPostureLogService) {
+        this.findFcmTokenService = findFcmTokenService;
+        this.requestPostFcmMessage = requestPostFcmMessage;
+        this.findDailyPostureLogService = findDailyPostureLogService;
+    }
+
+    @Transactional
+    public boolean postDailyPostureLogMessage(Long memberId) {
+        FindFcmTokenDTO findFcmTokenDTO = findFcmTokenService.findByMemberId(memberId);
+        DailyPostureLogDTO dailyPostureLogDTO = findDailyPostureLogService.getSummary(memberId);
+        return requestPostFcmMessage.send("오늘의 자세 요약", dailyPostureLogDTO.toString(), findFcmTokenDTO.getFcmToken());
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/PostPostureLogMessageService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/PostPostureLogMessageService.java
@@ -24,9 +24,11 @@ public class PostPostureLogMessageService {
     }
 
     @Transactional
-    public boolean postDailyPostureLogMessage(Long memberId) {
+    public void postDailyPostureLogMessage(Long memberId) {
         FindFcmTokenDTO findFcmTokenDTO = findFcmTokenService.findByMemberId(memberId);
+        System.out.println("findFcmTokenDTO = " + findFcmTokenDTO);
         DailyPostureLogDTO dailyPostureLogDTO = findDailyPostureLogService.getSummary(memberId);
-        return requestPostFcmMessage.send("오늘의 자세 요약", dailyPostureLogDTO.toString(), findFcmTokenDTO.getFcmToken());
+        System.out.println("dailyPostureLogDTO = " + dailyPostureLogDTO);
+        requestPostFcmMessage.send("오늘의 자세 요약", dailyPostureLogDTO.toString(), findFcmTokenDTO.getFcmToken());
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/domain/service/RequestPostFcmMessage.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/domain/service/RequestPostFcmMessage.java
@@ -1,0 +1,6 @@
+package com.spinetracker.spinetracker.domain.posture.command.domain.service;
+
+public interface RequestPostFcmMessage {
+
+    boolean send(String title, String body, String receiverToken);
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/infra/service/RequestPostFcmMessageImpl.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/infra/service/RequestPostFcmMessageImpl.java
@@ -1,0 +1,22 @@
+package com.spinetracker.spinetracker.domain.posture.command.infra.service;
+
+import com.spinetracker.spinetracker.domain.posture.command.domain.service.RequestPostFcmMessage;
+import com.spinetracker.spinetracker.global.common.annotation.InfraService;
+import com.spinetracker.spinetracker.infra.firebase.command.infra.service.PostMessageService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@InfraService
+public class RequestPostFcmMessageImpl  implements RequestPostFcmMessage {
+
+    private final PostMessageService postMessageService;
+
+    @Autowired
+    public RequestPostFcmMessageImpl(PostMessageService postMessageService) {
+        this.postMessageService = postMessageService;
+    }
+
+    @Override
+    public boolean send(String title, String body, String receiverToken) {
+        return postMessageService.sendToToken(title, body, receiverToken);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
@@ -120,7 +120,7 @@ public class SecurityConfiguration {
                 .authorizeRequests()
                     .antMatchers("/oauth2/**", "/auth/**")
                         .hasRole(RoleEnum.MEMBER.name())
-                .antMatchers("/blog/**", "/member/**", "/board/**")
+                .antMatchers("/blog/**", "/member/**", "/board/**", "/posture/**", "/fcm/**")
                     .permitAll()
                 .antMatchers("/admin/**")
                     .hasRole(RoleEnum.ADMIN.name())

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/application/dto/ResponseFcmToken.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/application/dto/ResponseFcmToken.java
@@ -2,7 +2,6 @@ package com.spinetracker.spinetracker.infra.firebase.command.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/infra/service/PostMessageService.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/infra/service/PostMessageService.java
@@ -18,7 +18,7 @@ public class PostMessageService {
         this.firebaseMessaging = firebaseMessaging;
     }
 
-    public boolean sendToToken(String title, String body, String receiverToken) throws FirebaseMessagingException {
+    public boolean sendToToken(String title, String body, String receiverToken) {
         // [START send_to_token]
         // This registration token comes from the client FCM SDKs.
         String registrationToken = "YOUR_REGISTRATION_TOKEN";

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/controller/FindFcmTokenController.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/controller/FindFcmTokenController.java
@@ -1,0 +1,48 @@
+package com.spinetracker.spinetracker.infra.firebase.query.application.controller;
+
+import com.spinetracker.spinetracker.global.common.annotation.CurrentMember;
+import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import com.spinetracker.spinetracker.infra.firebase.command.application.dto.ResponseFcmToken;
+import com.spinetracker.spinetracker.infra.firebase.query.application.dto.FindFcmTokenDTO;
+import com.spinetracker.spinetracker.infra.firebase.query.application.service.FindFcmTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name="FCM TOKEN", description = "FCM 토큰 관련 API")
+@RestController
+@RequestMapping("/fcm")
+public class FindFcmTokenController {
+
+    private final FindFcmTokenService findFcmTokenService;
+
+    @Autowired
+    public FindFcmTokenController(FindFcmTokenService findFcmTokenService) {
+        this.findFcmTokenService = findFcmTokenService;
+    }
+
+    @Operation(
+            summary = "FCM 토큰 조회",
+            description = "사용자의 토큰을 기반으로 사용자의 웹 푸시용 토큰을 조회합니다."
+    )
+    // response 정보
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Ok", content = { @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseFcmToken.class))}),
+            //@ApiResponse(code = 204, message = "member not exists"),
+    })
+    @GetMapping
+    public ResponseEntity<ResponseFcmToken> create(@CurrentMember UserPrincipal userPrincipal) {
+        Long memberId = userPrincipal.getId();
+
+        FindFcmTokenDTO findFcmTokenDTO = findFcmTokenService.findByMemberId(memberId);
+
+        return ResponseEntity.ok().body(new ResponseFcmToken(memberId, findFcmTokenDTO.getFcmToken()));
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/dto/FindFcmTokenDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/dto/FindFcmTokenDTO.java
@@ -1,0 +1,28 @@
+package com.spinetracker.spinetracker.infra.firebase.query.application.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class FindFcmTokenDTO {
+    private Long id;
+    private Long memberId;
+    private String FcmToken;
+
+    public FindFcmTokenDTO() {}
+
+    public FindFcmTokenDTO(Long id, Long memberId, String fcmToken) {
+        this.id = id;
+        this.memberId = memberId;
+        FcmToken = fcmToken;
+    }
+
+    public void setMemberId(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public void setFcmToken(String fcmToken) {
+        FcmToken = fcmToken;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/service/FindFcmTokenService.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/service/FindFcmTokenService.java
@@ -1,0 +1,21 @@
+package com.spinetracker.spinetracker.infra.firebase.query.application.service;
+
+import com.spinetracker.spinetracker.infra.firebase.query.application.dto.FindFcmTokenDTO;
+import com.spinetracker.spinetracker.infra.firebase.query.domain.repository.FcmTokenMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FindFcmTokenService {
+
+    private final FcmTokenMapper fcmTokenMapper;
+
+    @Autowired
+    public FindFcmTokenService(FcmTokenMapper fcmTokenMapper) {
+        this.fcmTokenMapper = fcmTokenMapper;
+    }
+
+    public FindFcmTokenDTO findByMemberId(Long memberId) {
+        return fcmTokenMapper.findByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/domain/repository/FcmTokenMapper.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/domain/repository/FcmTokenMapper.java
@@ -1,0 +1,10 @@
+package com.spinetracker.spinetracker.infra.firebase.query.domain.repository;
+
+import com.spinetracker.spinetracker.infra.firebase.query.application.dto.FindFcmTokenDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FcmTokenMapper {
+
+    FindFcmTokenDTO findByMemberId(Long memberId);
+}

--- a/src/main/resources/mapper/fcmToken/FcmTokenMapper.xml
+++ b/src/main/resources/mapper/fcmToken/FcmTokenMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.spinetracker.spinetracker.infra.firebase.query.domain.repository.FcmTokenMapper">
+    <resultMap id="FcmTokenMap" type="com.spinetracker.spinetracker.infra.firebase.query.application.dto.FindFcmTokenDTO">
+        <id property="id" column="id"/>
+        <result property="memberId" column="member_id"/>
+        <result property="FcmToken" column="token"/>
+    </resultMap>
+
+    <select id="findByMemberId" resultMap="FcmTokenMap">
+        SELECT
+            id
+        ,   member_id
+        ,   token
+        FROM
+            FCM_TOKEN_TB
+        WHERE
+            member_id = #{memberId}
+    </select>
+</mapper>
+

--- a/src/test/java/com/spinetracker/spinetracker/domain/posture/command/application/controller/CreatePostureControllerTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/posture/command/application/controller/CreatePostureControllerTest.java
@@ -13,6 +13,8 @@ import com.spinetracker.spinetracker.global.filter.TokenAuthenticationFilter;
 import com.spinetracker.spinetracker.global.security.command.application.service.CustomUserDetailService;
 import com.spinetracker.spinetracker.global.security.command.domain.service.CustomTokenService;
 import com.spinetracker.spinetracker.global.security.token.UserPrincipal;
+import com.spinetracker.spinetracker.infra.firebase.query.application.dto.FindFcmTokenDTO;
+import com.spinetracker.spinetracker.infra.firebase.query.application.service.FindFcmTokenService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,6 +60,9 @@ class CreatePostureControllerTest {
 
     @MockBean
     private FindMemberService findMemberService;
+
+    @MockBean
+    private FindFcmTokenService findFcmTokenService;
 
     @Autowired
     private CustomTokenService customTokenService;
@@ -120,6 +125,13 @@ class CreatePostureControllerTest {
                 RoleEnum.valueOf(userPrincipal.getRole().substring(5)).name()
         );
         when(findMemberService.findById(userPrincipal.getId())).thenReturn(mockFindMemberDTO);
+
+        FindFcmTokenDTO mockFindFcmTokenDTO = new FindFcmTokenDTO(
+                0L,
+                userPrincipal.getId(),
+                "mockFcmToken"
+        );
+        when(findFcmTokenService.findByMemberId(userPrincipal.getId())).thenReturn(mockFindFcmTokenDTO);
 
         String content = objectMapper.writeValueAsString(createPostureLogDTO);
 


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #99 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 깃허브 액션 실행 yml 파일에서 FIREBASE_ADMIN_SDK json 파일을 불러올 때 application.yml 파일로 같은 방식으로 파일을 생성할 경우 json 파싱 에러가 발생하였습니다. 이 문제를 해결하기 위해 `jsdaniell/create-json@1.1.2` 패키지를 사용하여 FIREBASE_ADMIN_SDK json 파일을 생성하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 사용자의 JWT 토큰을 통해 Fcm 토큰을 조회하는 API를 구현하였습니다.
* 자세 태그가 END일 경우 사용자의 FCM 토큰을 조회한 후, 일단 자세 요약 정보를 FCM을 통해 웹 푸시하도록 구현하였습니다.
---

# 관련 스크린샷

<img width="1448" alt="CleanShot 2023-09-25 at 09 04 47@2x" src="https://github.com/SpineTracker60/back-end/assets/19159759/382d27c2-f726-4216-80bb-fa316259fd84">

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* `CreatePostureControllerTest` 에서 자세 로그 저장 API 테스트를 할 때 `when(findFcmTokenService.findByMemberId(userPrincipal.getId())).thenReturn(mockFindFcmTokenDTO);` 를 통해 임시 FCM 토큰 DTO를 응답하도록 수정하였습니다.
