### PR TITLE
[Closes #109] Refactor : FCM 클라이언트 연결 리팩토링

### DIFF
--- a/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/PostPostureLogMessageService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/posture/command/application/service/PostPostureLogMessageService.java
@@ -26,9 +26,7 @@ public class PostPostureLogMessageService {
     @Transactional
     public void postDailyPostureLogMessage(Long memberId) {
         FindFcmTokenDTO findFcmTokenDTO = findFcmTokenService.findByMemberId(memberId);
-        System.out.println("findFcmTokenDTO = " + findFcmTokenDTO);
         DailyPostureLogDTO dailyPostureLogDTO = findDailyPostureLogService.getSummary(memberId);
-        System.out.println("dailyPostureLogDTO = " + dailyPostureLogDTO);
         requestPostFcmMessage.send("오늘의 자세 요약", dailyPostureLogDTO.toString(), findFcmTokenDTO.getFcmToken());
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/application/dto/ResponseFcmToken.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/application/dto/ResponseFcmToken.java
@@ -2,22 +2,26 @@ package com.spinetracker.spinetracker.infra.firebase.command.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+@Setter
 public class ResponseFcmToken {
 
     @Schema(type = "Long", example = "1", description="사용자 번호 입니다.")
     @NotBlank
     @NotNull
     @JsonProperty("member_id")
-    private final Long memberId;
+    private Long memberId;
     @Schema(type = "String", example = "BKagOny0KF_2pCJQ3m....moL0ewzQ8rZu", description="Firebase에서 발급 받은 토큰 입니다.")
     @NotBlank
     @NotNull
     @JsonProperty("fcm_token")
-    private final String FcmToken;
+    private String FcmToken;
+
+    public ResponseFcmToken() {}
 
     public ResponseFcmToken(Long memberId, String fcmToken) {
         this.memberId = memberId;

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/infra/service/PostMessageService.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/command/infra/service/PostMessageService.java
@@ -1,9 +1,6 @@
 package com.spinetracker.spinetracker.infra.firebase.command.infra.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.*;
 import com.spinetracker.spinetracker.global.common.annotation.InfraService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -26,6 +23,7 @@ public class PostMessageService {
         // See documentation on defining a message payload.
         Notification notification = Notification.builder()
                 .setTitle(title)
+                .setImage("https://avatars.githubusercontent.com/u/19159759?s=400&u=0e0cc9ab7108cf605ef31085ba9451ec4dfb89e5&v=4")
                 .setBody(body)
                 .build();
 

--- a/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/controller/FindFcmTokenController.java
+++ b/src/main/java/com/spinetracker/spinetracker/infra/firebase/query/application/controller/FindFcmTokenController.java
@@ -43,6 +43,12 @@ public class FindFcmTokenController {
 
         FindFcmTokenDTO findFcmTokenDTO = findFcmTokenService.findByMemberId(memberId);
 
-        return ResponseEntity.ok().body(new ResponseFcmToken(memberId, findFcmTokenDTO.getFcmToken()));
+        ResponseFcmToken responseFcmToken = new ResponseFcmToken();
+        if(findFcmTokenDTO != null) {
+            responseFcmToken.setMemberId(findFcmTokenDTO.getMemberId());
+            responseFcmToken.setFcmToken(findFcmTokenDTO.getFcmToken());
+        }
+
+        return ResponseEntity.ok().body(responseFcmToken);
     }
 }


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #109 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 사용자가 FCM 토큰이 없을 경우 null형태의 `ResponseFcmToken` 을 응답하도록 수정하였습니다.
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 사용자가 FCM 토큰이 없을 경우 null형태의 `ResponseFcmToken` 을 응답하도록 수정하였습니다.
* 클라이언트의 푸시 알림 형태에 이미지가 들어가도록 수정하였습니다.
---

# 관련 스크린샷

![KakaoTalk_Photo_2023-09-25-23-19-44](https://github.com/SpineTracker60/back-end/assets/19159759/600b4c5e-a517-42db-8286-583bd4343831)

![KakaoTalk_Photo_2023-09-25-23-20-04](https://github.com/SpineTracker60/back-end/assets/19159759/b028ff55-cdbc-43ca-85c1-6a9aa03576e5)

---
* 없음
---

# 테스트 계획 또는 완료 사항

---
* 없음
