### PR TITLE
[Closes #108] Refactoring : 상품 생성 및 게시글 조회 refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
     implementation 'com.google.firebase:firebase-admin:7.1.1'
+    implementation 'net.sourceforge.htmlcleaner:htmlcleaner:2.6.1'
+
 
 
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.6'

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/ProductController.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/controller/ProductController.java
@@ -1,0 +1,39 @@
+package com.spinetracker.spinetracker.domain.board.command.application.controller;
+
+import com.spinetracker.spinetracker.domain.board.command.application.dto.CreateProductDTO;
+import com.spinetracker.spinetracker.domain.board.command.application.dto.ProductUrlRequestDTO;
+import com.spinetracker.spinetracker.domain.board.command.application.service.CreateBoardService;
+import com.spinetracker.spinetracker.domain.board.command.domain.aggregate.lib.OpenGraph;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.Arrays;
+
+@RestController
+@RequestMapping("/product")
+public class ProductController {
+
+    private final CreateBoardService createBoardService;
+
+    @Autowired
+    public ProductController(CreateBoardService createBoardService) {
+        this.createBoardService = createBoardService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ProductUrlRequestDTO> createProduct(@RequestBody ProductUrlRequestDTO productUrlRequestDTO) throws Exception {
+
+        OpenGraph productOG = new OpenGraph(productUrlRequestDTO.getProductUrl(), true);
+        createBoardService.createProduct( new CreateProductDTO(null,productOG.getContent("url"),productOG.getContent("image"),productOG.getContent("title")));
+
+        return ResponseEntity.created(URI.create("/product"))
+                .body(new ProductUrlRequestDTO(
+                        productUrlRequestDTO.getProductUrl()
+                ));
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/CreatePostDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/CreatePostDTO.java
@@ -12,34 +12,31 @@ public class CreatePostDTO {
     @Schema(type = "Long", example = "1", description = "글 작성자 번호 입니다.")
     private Long writer;
 
-    @Schema(type = "String", example = "상품 이름", description = "상품 이름 입니다.")
-    @JsonProperty("product_name")
-    private String productName;
+//    @Schema(type = "String", example = "상품 이름", description = "상품 이름 입니다.")
+//    @JsonProperty("product_name")
+//    private String productName;
 
     @Schema(type = "String", example = "게시글 내용", description = "게시글 본문 내용 입니다.")
     private String content;
 
-    @Schema(type = "Long", example = "1", description = "상품 번호 입니다.")
-    @JsonProperty("product_id")
-    private Long productId;
+//    @Schema(type = "Long", example = "1", description = "상품 번호 입니다.")
+//    @JsonProperty("product_id")
+//    private Long productId;
 
     @Schema(type = "String", example = "상품 URL", description = "상품 URL 입니다.")
     @JsonProperty("product_url")
     private String productUrl;
 
-    @Schema(type = "String", example = "이미지 URL", description = "이미지 URL 입니다.")
-    @JsonProperty("image_url")
-    private String imageUrl;
+//    @Schema(type = "String", example = "이미지 URL", description = "이미지 URL 입니다.")
+//    @JsonProperty("image_url")
+//    private String imageUrl;
 
     public CreatePostDTO() {}
 
-    public CreatePostDTO(Long writer, String productName, String content, Long productId, String productUrl, String imageUrl) {
+    public CreatePostDTO(Long writer, String content, String productUrl) {
         this.writer = writer;
-        this.productName = productName;
         this.content = content;
-        this.productId = productId;
         this.productUrl = productUrl;
-        this.imageUrl = imageUrl;
     }
 
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/ProductUrlRequestDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/dto/ProductUrlRequestDTO.java
@@ -1,0 +1,19 @@
+package com.spinetracker.spinetracker.domain.board.command.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ProductUrlRequestDTO {
+
+    @JsonProperty("product_url")
+    private String productUrl;
+
+    public ProductUrlRequestDTO() {}
+
+    public ProductUrlRequestDTO(String productUrl) {
+        this.productUrl = productUrl;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardService.java
@@ -30,15 +30,18 @@ public class CreateBoardService {
     public Board createPost(Long memberId,CreatePostDTO createPostDTO) {
         WriterVO writerVO = new WriterVO(memberId);
 
-        CreateProductDTO createProductDTO = new CreateProductDTO(
-                createPostDTO.getProductId(),
-                createPostDTO.getProductUrl(),
-                createPostDTO.getImageUrl(),
-                createPostDTO.getProductName()
-        );
-        createProduct(createProductDTO);
+//        CreateProductDTO createProductDTO = new CreateProductDTO(
+//                createPostDTO.getProductId(),
+//                createPostDTO.getProductUrl(),
+//                createPostDTO.getImageUrl(),
+//                createPostDTO.getProductName()
+//        );
+//        createProduct(createProductDTO);
 
-        ProductVO productVO = new ProductVO(createPostDTO.getProductId());
+        String[] array = createPostDTO.getProductUrl().split("/");
+        String product = array[5].split("\\?")[0];
+        Long productId = Long.parseLong(product);
+        ProductVO productVO = new ProductVO(productId);
         Board createdPost = new Board(
                 createPostDTO.getContent(),
                 writerVO,

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/lib/MetaElement.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/lib/MetaElement.java
@@ -1,0 +1,71 @@
+package com.spinetracker.spinetracker.domain.board.command.domain.aggregate.lib;
+
+import java.net.URL;
+
+/**
+ * Represents OpenGraph enabled meta data for a specific document
+ * @author Callum Jones
+ */
+public class MetaElement
+{
+    private OpenGraphNamespace namespace; //either "og" an NS specific
+    private String property;
+    private String content;
+
+    /**
+     * Construct the representation of an element
+     * @param namespace The namespace the element belongs to
+     * @param property The property key
+     * @param content The content or value of this element
+     */
+    public MetaElement(OpenGraphNamespace namespace, String property, String content)
+    {
+        this.namespace = namespace;
+        this.property = property;
+        this.content = content;
+    }
+
+    /**
+     * Fetch the content string of the element
+     */
+    public String getContent()
+    {
+        return content;
+    }
+
+    /**
+     * Fetch the OpenGraph namespace
+     */
+    public OpenGraphNamespace getNamespace()
+    {
+        return namespace;
+    }
+
+    /**
+     * Fetch the property of the element
+     */
+    public String getProperty()
+    {
+        return property;
+    }
+
+    /**
+     * Fetch the OpenGraph data from the object
+     * @return If the content is a URL, then an attempted will be made to build OpenGraph data from the object
+     */
+    public OpenGraph getExtendedData()
+    {
+        //The Java language should know the best form of a URL
+        try
+        {
+            URL url = new URL(getContent());
+
+            //success
+            return new OpenGraph(url.toString(), true);
+        }
+        catch (Exception e)
+        {
+            return null; //not a valid URL
+        }
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/lib/OpenGraph.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/lib/OpenGraph.java
@@ -1,0 +1,410 @@
+package com.spinetracker.spinetracker.domain.board.command.domain.aggregate.lib;
+
+import org.htmlcleaner.HtmlCleaner;
+import org.htmlcleaner.TagNode;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A Java object representation of an Open Graph enabled webpage.
+ * A simplified layer over a Hastable.
+ *
+ * @author Callum Jones
+ */
+public class OpenGraph
+{
+    private String pageUrl;
+    private ArrayList<OpenGraphNamespace> pageNamespaces;
+    private Hashtable<String, ArrayList<MetaElement>> metaAttributes;
+    private String baseType;
+    private boolean isImported; // determine if the object is a new incarnation or representation of a web page
+    private boolean hasChanged; // track if object has been changed
+
+    public final static String[] REQUIRED_META = new String[]{"title", "type", "image", "url" };
+
+    public final static Hashtable<String, String[]> BASE_TYPES = new Hashtable<String, String[]>();
+    static
+    {
+        BASE_TYPES.put("activity", new String[] {"activity", "sport"});
+        BASE_TYPES.put("business", new String[] {"bar", "company", "cafe", "hotel", "restaurant"});
+        BASE_TYPES.put("group", new String[] {"cause", "sports_league", "sports_team"});
+        BASE_TYPES.put("organization", new String[] {"band", "government", "non_profit", "school", "university"});
+        BASE_TYPES.put("person", new String[] {"actor", "athlete", "author", "director", "musician", "politician", "profile", "public_figure"});
+        BASE_TYPES.put("place", new String[] {"city", "country", "landmark", "state_province"});
+        BASE_TYPES.put("product", new String[] {"album", "book", "drink", "food", "game", "movie", "product", "song", "tv_show"});
+        BASE_TYPES.put("website", new String[] {"blog", "website", "article"});
+    }
+
+    /**
+     * Create an open graph representation for generating your own Open Graph object
+     */
+    public OpenGraph()
+    {
+        pageNamespaces = new ArrayList<OpenGraphNamespace>();
+        metaAttributes = new Hashtable<String, ArrayList<MetaElement>>();
+        hasChanged = false;
+        isImported = false;
+    }
+
+    /**
+     * Fetch the open graph representation from a web site
+     * @param url The address to the web page to fetch Open Graph data
+     * @param ignoreSpecErrors Set this option to true if you don't wish to have an exception throw if the page does not conform to the basic 4 attributes
+     * @throws java.io.IOException If a network error occurs, the HTML parser will throw an IO Exception
+     * @throws java.lang.Exception A generic exception is throw if the specific page fails to conform to the basic Open Graph standard as define by the constant REQUIRED_META
+     */
+    public OpenGraph(String url, boolean ignoreSpecErrors) throws java.io.IOException, Exception {
+        this();
+        isImported = true;
+
+
+        // download the (X)HTML content, but only up to the closing head tag. We do not want to waste resources parsing irrelevant content
+        URL pageURL = new URL(url);
+        URLConnection siteConnection = pageURL.openConnection();
+        siteConnection.setRequestProperty("User-Agent", "Googlebot");
+        siteConnection.setRequestProperty("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7,ar;q=0.6");
+        Charset charset = getConnectionCharset(siteConnection);
+        BufferedReader dis = new BufferedReader(new InputStreamReader(siteConnection.getInputStream(), charset));
+        String inputLine;
+        StringBuffer headContents = new StringBuffer();
+
+        // Loop through each line, looking for the closing head element
+        while ((inputLine = dis.readLine()) != null)
+        {
+            if (inputLine.contains("</head>"))
+            {
+                inputLine = inputLine.substring(0, inputLine.indexOf("</head>") + 7);
+                inputLine = inputLine.concat("<body></body></html>");
+                headContents.append(inputLine + "\r\n");
+                break;
+            }
+            headContents.append(inputLine + "\r\n");
+        }
+
+        String headContentsStr = headContents.toString();
+        HtmlCleaner cleaner = new HtmlCleaner();
+        // parse the string HTML
+        TagNode pageData = cleaner.clean(headContentsStr);
+
+        // read in the declared namespaces
+        boolean hasOGspec = false;
+        TagNode headElement = pageData.findElementByName("head", true);
+        if (headElement.hasAttribute("prefix"))
+        {
+            String namespaceData = headElement.getAttributeByName("prefix");
+            Pattern pattern = Pattern.compile("(([A-Za-z0-9_]+):\\s+(http:\\/\\/ogp.me\\/ns(\\/\\w+)*#))\\s*");
+            Matcher matcher = pattern.matcher(namespaceData);
+            while (matcher.find())
+            {
+                String prefix = matcher.group(2);
+                String documentURI = matcher.group(3);
+                pageNamespaces.add(new OpenGraphNamespace(prefix, documentURI));
+                if (prefix.equals("og"))
+                    hasOGspec = true;
+            }
+        }
+
+        // some pages do not include the new OG spec
+        // this fixes compatibility
+        if (!hasOGspec)
+            pageNamespaces.add(new OpenGraphNamespace("og", "http:// ogp.me/ns#"));
+
+        // open only the meta tags
+        TagNode[] metaData = pageData.getElementsByName("meta", true);
+        for (TagNode metaElement : metaData)
+        {
+            for (OpenGraphNamespace namespace : pageNamespaces)
+            {
+                String target = null;
+                if (metaElement.hasAttribute("property"))
+                    target = "property";
+                else if (metaElement.hasAttribute("name"))
+                    target = "name";
+
+                if (target != null && metaElement.getAttributeByName(target).startsWith(namespace.getPrefix() + ":"))
+                {
+                    setProperty(namespace, metaElement.getAttributeByName(target), metaElement.getAttributeByName("content"));
+                    break;
+                }
+            }
+        }
+
+        /**
+         * Check that page conforms to Open Graph protocol
+         */
+        if (!ignoreSpecErrors)
+        {
+            for (String req : REQUIRED_META)
+            {
+                if (!metaAttributes.containsKey(req))
+                    throw new Exception("Does not conform to Open Graph protocol");
+            }
+        }
+
+        /**
+         * Has conformed, now determine basic sub type.
+         */
+        baseType = null;
+        String currentType = getContent("type");
+        // some apps use their OG namespace as a prefix
+        if (currentType != null)
+        {
+            for (OpenGraphNamespace ns : pageNamespaces)
+            {
+                if (currentType.startsWith(ns.getPrefix() + ":"))
+                {
+                    currentType = currentType.replaceFirst(ns.getPrefix() + ":","");
+                    break; // done here
+                }
+            }
+        }
+        for (String base : BASE_TYPES.keySet())
+        {
+            String[] baseList = BASE_TYPES.get(base);
+            boolean finished = false;
+            for (String expandedType : baseList)
+            {
+                if (expandedType.equals(currentType))
+                {
+                    baseType = base;
+                    finished = true;
+                    break;
+                }
+            }
+            if (finished) break;
+        }
+
+        // read the original page url
+        URL realURL = siteConnection.getURL();
+        pageUrl = realURL.toExternalForm();
+    }
+
+    /**
+     * Gets the charset for specified connection.
+     * Content Type header is parsed to get the charset name.
+     *
+     * @param connection the connection.
+     * @return the Charset object for response charset name;
+     *         if it's not found then the default charset.
+     */
+    private static Charset getConnectionCharset(URLConnection connection)
+    {
+        String contentType = connection.getContentType();
+        if (contentType != null && contentType.length() > 0)
+        {
+            contentType = contentType.toLowerCase();
+            String charsetName = extractCharsetName(contentType);
+            if (charsetName != null && charsetName.length() > 0)
+            {
+                try
+                {
+                    return Charset.forName(charsetName);
+                }
+                catch (Exception e) {
+                    // specified charset is not found,
+                    // skip it to return the default one
+                }
+            }
+        }
+
+        // return the default charset
+        return Charset.defaultCharset();
+    }
+
+    /**
+     * Extract the charset name form the content type string.
+     * Content type string is received from Content-Type header.
+     *
+     * @param contentType the content type string, must be not null.
+     * @return the found charset name or null if not found.
+     */
+    private static String extractCharsetName(String contentType)
+    {
+        // split onto media types
+        final String[] mediaTypes = contentType.split(":");
+        if (mediaTypes.length > 0)
+        {
+            // use only the first one, and split it on parameters
+            final String[] params = mediaTypes[0].split(";");
+
+            // find the charset parameter and return it's value
+            for (String each : params)
+            {
+                each = each.trim();
+                if (each.startsWith("charset="))
+                {
+                    // return the charset name
+                    return each.substring(8).trim();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the basic type of the Open graph page as per the specification
+     * @return Base type as defined by specification, null otherwise
+     */
+    public String getBaseType()
+    {
+        return baseType;
+    }
+
+    /**
+     * Get a value of a given Open Graph property
+     * @param property The Open graph property key
+     * @return Returns the value of the first property defined, null otherwise
+     */
+    public String getContent(String property)
+    {
+        if (metaAttributes.containsKey(property) && metaAttributes.get(property).size() > 0)
+            return metaAttributes.get(property).get(0).getContent();
+        else
+            return null;
+    }
+
+    /**
+     * Get all the defined properties of the Open Graph object
+     * @return An array of all currently defined properties
+     */
+    public MetaElement[] getProperties()
+    {
+        ArrayList<MetaElement> allElements = new ArrayList<MetaElement>();
+        for (ArrayList<MetaElement> collection : metaAttributes.values())
+            allElements.addAll(collection);
+
+        return (MetaElement[]) allElements.toArray(new MetaElement[allElements.size()]);
+    }
+
+    /**
+     * Get all the defined properties of the Open Graph object
+     * @param property The property to focus on
+     * @return An array of all currently defined properties
+     */
+    public MetaElement[] getProperties(String property)
+    {
+        if (metaAttributes.containsKey(property))
+        {
+            ArrayList target = metaAttributes.get(property);
+            return (MetaElement[]) target.toArray(new MetaElement[target.size()]);
+        }
+        else
+            return null;
+    }
+
+    /**
+     * Get the original URL the Open Graph page was obtained from
+     * @return The address to the Open Graph object page
+     */
+    public String getOriginalUrl()
+    {
+        return pageUrl;
+    }
+
+
+    /**
+     * Get the HTML representation of the Open Graph data.
+     * @return An array of meta elements as Strings
+     */
+    public String[] toHTML()
+    {
+        // allocate the array
+        ArrayList<String> returnHTML = new ArrayList<String>();
+
+        int index = 0; // keep track of the index to insert into
+        for (ArrayList<MetaElement> elements : metaAttributes.values())
+        {
+            for (MetaElement element : elements)
+                returnHTML.add("<meta property=\"" + element.getNamespace() + ":" +
+                        element.getProperty() + "\" content=\"" + element.getContent() + "\" />");
+        }
+
+        // return the array
+        return (String[]) returnHTML.toArray();
+    }
+
+    /**
+     * Get the XHTML representation of the Open Graph data.
+     * @return An array of meta elements as Strings
+     */
+    public String[] toXHTML()
+    {
+        // allocate the array
+        ArrayList<String> returnHTML = new ArrayList<String>();
+
+        int index = 0; // keep track of the index to insert into
+        for (ArrayList<MetaElement> elements : metaAttributes.values())
+        {
+            for (MetaElement element : elements)
+                returnHTML.add("<meta name=\"" + element.getNamespace().getPrefix() + ":" +
+                        element.getProperty() + "\" content=\"" + element.getContent() + "\" />");
+        }
+
+        // return the array
+        return (String[]) returnHTML.toArray();
+    }
+
+    /**
+     * Set the Open Graph property to a specific value
+     * @param namespace The OpenGraph namespace the content belongs to
+     * @param property The og:XXXX where XXXX is the property you wish to set
+     * @param content The value or contents of the property to be set
+     */
+    public void setProperty(OpenGraphNamespace namespace, String property, String content)
+    {
+        if (!pageNamespaces.contains(namespace))
+            pageNamespaces.add(namespace);
+
+        property = property.replaceAll(namespace.getPrefix() + ":", "");
+        MetaElement element = new MetaElement(namespace, property, content);
+        if (!metaAttributes.containsKey(property))
+            metaAttributes.put(property, new ArrayList<MetaElement>());
+
+        metaAttributes.get(property).add(element);
+    }
+
+    /**
+     * Removed a defined property
+     * @param property The og:XXXX where XXXX is the property you wish to remove
+     */
+    public void removeProperty(String property)
+    {
+        metaAttributes.remove(property);
+    }
+
+    /**
+     * Obtain the underlying HashTable
+     * @return The underlying structure as a Hashtable
+     */
+    public Hashtable<String, ArrayList<MetaElement>> exposeTable() {
+        return metaAttributes;
+    }
+
+    /**
+     * Test if the Open Graph object was initially a representation of a web page
+     * @return True if the object is from a web page, false otherwise
+     */
+    public boolean isFromWeb()
+    {
+        return isImported;
+    }
+
+    /**
+     * Test if the object has been modified by setters/deleters.
+     * This is only relevant if this object initially represented a web page
+     * @return True True if the object has been modified, false otherwise
+     */
+    public boolean hasChanged()
+    {
+        return hasChanged;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/lib/OpenGraphNamespace.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/command/domain/aggregate/lib/OpenGraphNamespace.java
@@ -1,0 +1,34 @@
+package com.spinetracker.spinetracker.domain.board.command.domain.aggregate.lib;
+
+public class OpenGraphNamespace
+{
+    private String prefix;
+    private String schemaURI;
+
+    /**
+     * Construct a namespace
+     * @param prefix The OpenGraph assigned namespace prefix such as og or og_appname
+     * @param schemaURI The URL for the OpenGraph schema
+     */
+    public OpenGraphNamespace(String prefix, String schemaURI)
+    {
+        this.prefix = prefix;
+        this.schemaURI = schemaURI;
+    }
+
+    /*
+     * Fetch the prefix used for the namespace
+     */
+    public String getPrefix()
+    {
+        return prefix;
+    }
+
+    /*
+     * Fetch the address for the schema reference
+     */
+    public String getSchemaURI()
+    {
+        return schemaURI;
+    }
+}

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindBoardDTO.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/dto/FindBoardDTO.java
@@ -28,26 +28,27 @@ public class FindBoardDTO {
     @Schema(type = "String", example = "게시글 내용", description = "게시글 본문 내용 입니다.")
     private final String content;
 
-    @Schema(type = "String", example = "상품 이름", description = "상품 이름 입니다.")
-    @JsonProperty("product_name")
-    private final String productName;
-
+//    @Schema(type = "String", example = "상품 이름", description = "상품 이름 입니다.")
+//    @JsonProperty("product_name")
+//    private final String productName;
+//
     @Schema(type = "String", example = "상품 URL", description = "상품 URL 입니다.")
     @JsonProperty("product_url")
     private final String productUrl;
+//
+//    @Schema(type = "String", example = "이미지 URL", description = "이미지 URL 입니다.")
+//    @JsonProperty("image_url")
+//    private final String imageUrl;
 
-    @Schema(type = "String", example = "이미지 URL", description = "이미지 URL 입니다.")
-    @JsonProperty("image_url")
-    private final String imageUrl;
-
-    public FindBoardDTO(Long boardId, Long writerId, String writerName, String profileImage, String content, String productName, String productUrl, String imageUrl) {
+    public FindBoardDTO(Long boardId, Long writerId, String writerName, String profileImage, String content, Long productId) {
         this.boardId = boardId;
         this.writerId = writerId;
         this.writerName = writerName;
         this.profileImage = profileImage;
         this.content = content;
-        this.productName = productName;
-        this.productUrl = productUrl;
-        this.imageUrl = imageUrl;
+//        this.productName = productName;
+//        this.productUrl = productUrl;
+//        this.imageUrl = imageUrl;
+        this.productUrl = "https://www.coupang.com/vp/products/" + productId;
     }
 }

--- a/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
+++ b/src/main/java/com/spinetracker/spinetracker/domain/board/query/application/service/FindBoardService.java
@@ -2,7 +2,6 @@ package com.spinetracker.spinetracker.domain.board.query.application.service;
 
 import com.spinetracker.spinetracker.domain.board.query.application.dto.FindBoardDTO;
 import com.spinetracker.spinetracker.domain.board.query.application.dto.FindPostDTO;
-import com.spinetracker.spinetracker.domain.board.query.application.dto.FindProductDTO;
 import com.spinetracker.spinetracker.domain.board.query.domain.repository.BoardMapper;
 import com.spinetracker.spinetracker.domain.member.query.application.dto.FindMemberDTO;
 import com.spinetracker.spinetracker.domain.member.query.application.service.FindMemberService;
@@ -35,7 +34,7 @@ public class FindBoardService {
         List<FindBoardDTO> findBoardDTOList = new ArrayList<>();
 
         for (FindPostDTO findPost : findAllPostList) {
-            FindProductDTO findProduct = findProductService.findById(findPost.getProductId());
+//            FindProductDTO findProduct = findProductService.findById(findPost.getProductId());
             FindMemberDTO findMember = findMemberService.findById(findPost.getWriterId());
             findBoardDTOList.add(
               new FindBoardDTO(
@@ -44,10 +43,10 @@ public class FindBoardService {
                       findMember.getName(),
                       findMember.getProfileImage(),
                       findPost.getContent(),
-                      findProduct.getProductName(),
-                      findProduct.getProductUrl(),
-                      findProduct.getImageUrl()
-              )
+//                      findProduct.getProductName(),
+//                      findProduct.getProductUrl(),
+//                      findProduct.getImageUrl()
+                      findPost.getProductId())
             );
         }
 

--- a/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/spinetracker/spinetracker/global/configuration/SecurityConfiguration.java
@@ -120,7 +120,7 @@ public class SecurityConfiguration {
                 .authorizeRequests()
                     .antMatchers("/oauth2/**", "/auth/**")
                         .hasRole(RoleEnum.MEMBER.name())
-                .antMatchers("/blog/**", "/member/**", "/board/**", "/posture/**", "/fcm/**")
+                .antMatchers("/blog/**", "/member/**", "/board/**", "/posture/**", "/fcm/**", "/product/**")
                     .permitAll()
                 .antMatchers("/admin/**")
                     .hasRole(RoleEnum.ADMIN.name())

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
@@ -25,26 +25,26 @@ class CreateBoardServiceTest {
                         new CreatePostDTO(
                                 1L,
                                 "글 내용",
-                                "ASDASDASDSD"
+                                "https://www.coupang.com/vp/products/1601845545"
                                 )
                         )
         );
 
     }
 
-    private static Stream<Arguments> getCreateProduct() {
-        return Stream.of(
-                Arguments.of(
-                        new CreateProductDTO(
-                                1L,
-                                "상품 url",
-                                "이미지 url",
-                                "상품 이름"
-                        )
-                )
-        );
-
-    }
+//    private static Stream<Arguments> getCreateProduct() {
+//        return Stream.of(
+//                Arguments.of(
+//                        new CreateProductDTO(
+//                                1L,
+//                                "상품 url",
+//                                "이미지 url",
+//                                "상품 이름"
+//                        )
+//                )
+//        );
+//
+//    }
 
     @DisplayName("boardDTO를 통해 게시글이 생성 되는지 확인")
     @ParameterizedTest
@@ -57,14 +57,14 @@ class CreateBoardServiceTest {
         );
     }
 
-    @DisplayName("CreateProductDTO를 통해 상품이 생성 되는지 확인")
-    @ParameterizedTest
-    @MethodSource("getCreateProduct")
-    @Transactional
-    void createProduct(CreateProductDTO createProductDTO) {
-
-        Assertions.assertDoesNotThrow(
-                () -> createBoardService.createProduct(createProductDTO)
-        );
-    }
+//    @DisplayName("CreateProductDTO를 통해 상품이 생성 되는지 확인")
+//    @ParameterizedTest
+//    @MethodSource("getCreateProduct")
+//    @Transactional
+//    void createProduct(CreateProductDTO createProductDTO) {
+//
+//        Assertions.assertDoesNotThrow(
+//                () -> createBoardService.createProduct(createProductDTO)
+//        );
+//    }
 }

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/CreateBoardServiceTest.java
@@ -24,10 +24,7 @@ class CreateBoardServiceTest {
                         1L,
                         new CreatePostDTO(
                                 1L,
-                                "상품 이름",
                                 "글 내용",
-                                12121L,
-                                "ASKDAKDLDASD",
                                 "ASDASDASDSD"
                                 )
                         )

--- a/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardServiceTest.java
+++ b/src/test/java/com/spinetracker/spinetracker/domain/board/command/application/service/DeleteBoardServiceTest.java
@@ -26,10 +26,7 @@ class DeleteBoardServiceTest {
                         2L,
                         new CreatePostDTO(
                                 1L,
-                                "상품 이름",
                                 "글 내용",
-                                12121L,
-                                "ASKDAKDLDASD",
                                 "ASDASDASDSD"
                         )
                 )


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* #108 
---
# 어떤 위험이나 장애가 발견되었는지

---
* 없음
---

# 어떤 부분에 리뷰어가 집중하면 좋을지

---
* 게시글을 작성할 때 상품id를 저장하기 위해 상품 url에 split 메소드를 이용해서 구현하였습니다.
*  `FindBoardDTO`에 상품url을 기본 쿠팡 주소를 넣고 + productId로 넣어서 id를 통해 게시물이 조회 될 수 있게 구현하였습니다.
---

# 관련 스크린샷

---
<img width="584" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/a812c497-2a81-485c-a595-e2cbb03feb86">
<img width="578" alt="image" src="https://github.com/SpineTracker60/back-end/assets/122511826/8bd35e3d-757c-4e99-a874-15160605449d">

---

# 테스트 계획 또는 완료 사항

---
* 게시글 조회 및 생성 부분 테스트 수정 완료하였습니다.
